### PR TITLE
Cleanup and report re-naming

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -14,7 +14,7 @@ family = project
 
 rule all:
     input:
-        "report/coding/{family}".format(family=project),
+        "small_variants/coding/{family}".format(family=project),
         "sv/{family}.pbsv.csv".format(family=project),
-        "repeat_outliers/annotated_repeat_outliers.csv"
+        "repeat_outliers/{family}.repeat.outliers.annotated.csv".format(family=project)
 

--- a/rules/common.smk
+++ b/rules/common.smk
@@ -56,7 +56,7 @@ def format_pedigree(wildcards):
     return f"{family}.ped"
 
 def get_pbsv_vcf(wildcards):
-    family = wildcards.family
+    family = project
     input_vcf = units.loc[family, "pbsv_vcf"]
 
     return input_vcf

--- a/rules/outlier_expansions.smk
+++ b/rules/outlier_expansions.smk
@@ -1,10 +1,10 @@
 rule generate_allele_db:
     input: config["run"]["units"]
-    output: "repeat_outliers/alleles_db.gz"
+    output: "repeat_outliers/allele_db/{family}.alleles.db.gz"
     params:
         crg2_pacbio = config["tools"]["crg2_pacbio"],
         family = config["run"]["project"]
-    log: "logs/repeat_outliers/allele_db.log"
+    log: "logs/repeat_outliers/{family}_allele_db.log"
     resources:
         mem_mb = 10000
     conda:
@@ -17,9 +17,9 @@ rule generate_allele_db:
 
 rule sort_allele_db:
     input: 
-        input_file = "repeat_outliers/alleles_db.gz"
-    output: "repeat_outliers/sorted_alleles_db.gz"
-    log: "logs/repeat_outliers/sort_allele_db.log"
+        input_file = "repeat_outliers/allele_db/{family}.alleles.db.gz"
+    output: "repeat_outliers/allele_db/{family}.alleles.sorted.db.gz"
+    log: "logs/repeat_outliers/{family}.allele.sorted.db.log"
     shell:
         """
         (zcat < {input.input_file} | sort -T . -k 1,1 | gzip > {output}) > {log} 2>&1
@@ -27,13 +27,13 @@ rule sort_allele_db:
 
 rule find_repeat_outliers:
     input: 
-        alleles_path = "repeat_outliers/sorted_alleles_db.gz",
+        alleles_path = "repeat_outliers/allele_db/{family}.alleles.sorted.db.gz",
         case_ids = config["trgt"]["samples"]
     output:
-        out_path =  "repeat_outliers/repeat_outliers.csv"
+        out_path =  "repeat_outliers/{family}.repeat.outliers.csv"
     params:
         crg2_pacbio = config["tools"]["crg2_pacbio"]
-    log:  "logs/repeat_outliers/repeat_outliers.log"
+    log:  "logs/repeat_outliers/{family}.repeat.outliers.log"
     resources:
         mem_mb = 20000
     conda: 
@@ -47,14 +47,14 @@ rule find_repeat_outliers:
 
 
 rule annotate_repeat_outliers:
-    input: "repeat_outliers/repeat_outliers.csv"
-    output: "repeat_outliers/annotated_repeat_outliers.csv"
-    log:  "logs/repeat_outliers/annotate_repeat_outliers.log"
+    input: "repeat_outliers/{family}.repeat.outliers.csv"
+    output: "repeat_outliers/{family}.repeat.outliers.annotated.csv"
+    log:  "logs/repeat_outliers/{family}.annotate.repeat.outliers.log"
     params: 
       crg2_pacbio = config["tools"]["crg2_pacbio"],
       genes = config["trgt"]["ensembl_gtf"],
       OMIM = config["trgt"]["omim_path"],
-      HPO = config["hpo"] if config["hpo"] else "none",
+      HPO = config["run"]["hpo"] if config["run"]["hpo"] else "none",
       constraint = config["trgt"]["gnomad_constraint"]
     resources:
         mem_mb = 20000

--- a/rules/snvreport.smk
+++ b/rules/snvreport.smk
@@ -3,7 +3,7 @@ rule allsnvreport:
         db="annotated/{p}/{family}-gemini.db",
         vcf="annotated/{p}/vcfanno/{family}.{p}.vep.vcfanno.vcf.gz"
     output:
-        directory("report/{p}/{family}")
+        directory("small_variants/{p}/{family}")
     conda:
         "../envs/cre.yaml"
     log:

--- a/rules/svreport.smk
+++ b/rules/svreport.smk
@@ -7,7 +7,7 @@ rule snpeff:
     params:
         java_opts = config["params"]["snpeff"]["java_opts"],
         reference = config["ref"]["name"],
-        data_dir = config["annotation"]["snpeff"]["dataDir"]
+        data_dir = config["annotation"]["snpeff"]["data_dir"]
     wrapper:
         get_wrapper_path("snpeff")
 
@@ -38,7 +38,7 @@ rule sv_report:
         snpeff = "sv/{family}.pbsv.snpeff.vcf",
         annotsv = "sv/{family}.AnnotSV.tsv"
     output: "sv/{family}.pbsv.csv"
-    log: "logs/sv/{family}.sv_report.log"
+    log: "logs/sv/{family}.sv.report.log"
     params:
         crg2_pacbio = config["tools"]["crg2_pacbio"],
         hpo = config["run"]["hpo"],

--- a/scripts/annotate_repeat_outliers.py
+++ b/scripts/annotate_repeat_outliers.py
@@ -303,7 +303,7 @@ def main(hits: pd.DataFrame, out_file: str, ensembl: str, constraint: str, omim:
     today = today.strftime("%Y-%m-%d")
     out_file = out_file.replace(".csv", "")
     hits_gene_omim.to_csv(f"{out_file}.csv", index=False)
-    hits_gene_omim.to_csv(f"{out_file}_{today}.csv", index=False)
+    hits_gene_omim.to_csv(f"{out_file}.{today}.csv", index=False)
 
 
 

--- a/slurm_profile/config.yaml
+++ b/slurm_profile/config.yaml
@@ -1,4 +1,4 @@
-restart-times: 3
+restart-times: 0
 jobscript: "slurm-jobscript.sh"
 cluster: "slurm-submit.py"
 cluster-status: "slurm-status.py"


### PR DESCRIPTION
- make report naming consistents (i.e. periods instead of underscores, dates for all reports)
- prefix repeat outlier files with family name 