### PR TITLE
Genotype pathogenic repeats

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Repeat expansion outlier report
 - annnotate repeat outliers with [custom Python script](https://github.com/ccmbioinfo/crg2-pacbio/blob/master/scripts/annotate_repeat_outliers.py)
 
 Pathogenic repeat loci report
-- TRGT must have previously been run on each sample against the [pathogenic repeat loci BED file](https://github.com/PacificBiosciences/trgt/blob/main/repeats/pathogenic_repeats.hg38.bed) provided by TRGT
+- genotype repeats per-sample using TRGTv1.0.0 against the [pathogenic repeat loci BED file](https://github.com/PacificBiosciences/trgt/blob/main/repeats/pathogenic_repeats.hg38.bed) provided by TRGT (the GIAB 937,122 catalog only contains 50/56 loci). Note that TRGT requires BAMs; these must be added to the samples.tsv file
 - merge sample VCFs into multi-sample family VCF
 - annotate repeat loci with [custom Python script](https://github.com/ccmbioinfo/crg2-pacbio/blob/master/scripts/annotate_path_str_loci.py)
 

--- a/config.yaml
+++ b/config.yaml
@@ -16,6 +16,7 @@ tools:
   crg: "~/crg"
   crg2_pacbio: "~/crg2-pacbio"
   annotSV: "/hpf/largeprojects/ccmbio/ccmmarvin_shared/pacbio_longread_pilot_phase_1/annotate_SV/tools/AnnotSV-3.1.1"
+  trgt: "/hpf/largeprojects/ccmbio/ccmmarvin_shared/pacbio_longread_pilot_phase_2/tools/TRGTv1.0.0/trgt"
 
 ref:
   name: GRCh38.86
@@ -44,6 +45,7 @@ annotation:
       c4r: True # if samples belong to C4R, annotate against C4R pbsv SV database
       anno_path: "/hpf/largeprojects/ccmbio/ccmmarvin_shared/pacbio_longread_pilot_phase_1/annotate_SV/annotations/"
   pathogenic_repeats:
+      trgt_catalog: "/hpf/largeprojects/ccmbio/ccmmarvin_shared/pacbio_longread_pilot_phase_2/tools/TRGTv1.0.0/repeats/pathogenic_repeats.hg38.bed"
       disease_thresholds: "/hpf/largeprojects/ccm_dccforge/dccdipg/Common/annotation/ExpansionHunter/tandem_repeat_disease_loci_v1.1.tsv"
 
 params:

--- a/rules/common.smk
+++ b/rules/common.smk
@@ -66,3 +66,9 @@ def get_trgt_path_str_vcf_dir(wildcards):
     input_vcf = units.loc[family, "trgt_pathogenic_vcf_dir"]
 
     return input_vcf
+
+def get_bam(wildcards):
+    print(wildcards.sample)
+    bam = samples.loc[wildcards.sample, "BAM"]
+
+    return bam

--- a/samples.tsv
+++ b/samples.tsv
@@ -1,2 +1,2 @@
-sample
+sample  BAM
 NA12878

--- a/scripts/annotate_path_str_loci.py
+++ b/scripts/annotate_path_str_loci.py
@@ -33,8 +33,6 @@ def recode_genes(disease_thresholds):
     disease_thresholds.loc[
         disease_thresholds["Gene"] == "ATXN8/ATXN8OS", "Gene"
     ] = "ATXN8"
-    # disease_thresholds.loc[disease_thresholds["Gene"] == "NOTCH2NLC", "Gene"] = "NOTCH2NL"
-    # in the TRGT vcf, one locus is annotated as NOTCH2NL, one as NOTCH2NLC- are they both NOTCH2NLC?
     disease_thresholds.loc[disease_thresholds["Gene"] == "CBL2", "Gene"] = "CBL"
     disease_thresholds.loc[disease_thresholds["Gene"] == "XYLT", "Gene"] = "XYLT1"
     disease_thresholds.loc[disease_thresholds["Gene"] == "TK2/BEAN", "Gene"] = "BEAN1"
@@ -128,7 +126,7 @@ def main(vcf, disease_thresholds, output_file):
         "variants/ID",
         "variants/altlen",
         "variants/is_snp",
-        "calldata/ALCI",
+        "calldata/ALLR",
         "calldata/AM",
         "calldata/MC",
         "calldata/MS",
@@ -147,7 +145,7 @@ def main(vcf, disease_thresholds, output_file):
     )
 
     vcf_df = parse_sample_field(vcf_dict_pysam, vcf_df, "AL", "allele_length")
-    vcf_df = parse_sample_field(vcf_dict_pysam, vcf_df, "ALCI", "allele_CI")
+    vcf_df = parse_sample_field(vcf_dict_pysam, vcf_df, "ALLR", "allele_CI")
     vcf_df = parse_sample_field(vcf_dict_pysam, vcf_df, "MC", "motif_count")
     vcf_df = parse_sample_field(vcf_dict_pysam, vcf_df, "MS", "motif_span")
     vcf_df = parse_sample_field(vcf_dict_pysam, vcf_df, "AM", "avg_methylation")


### PR DESCRIPTION
Since TCAG only provides TRGT called against the GIAB catalog (937,122 loci), which only seems to cover 50 out of the 56 pathogenic repeat loci, I added a rule to genotype pathogenic repeats using TRGT.  Note that TRGT requires BAMs; per-sample BAMs must be added to the samples.tsv file. 