### PR TITLE
Pad insertions in population databases 

### DIFF
--- a/scripts/annotate_SVs.py
+++ b/scripts/annotate_SVs.py
@@ -271,6 +271,9 @@ def annotate_pop_svs(annotsv_df, pop_svs, cols):
     # intersect annotsv and population SV bed file
     annotsv_bed = annotsv_df_to_bed(annotsv_df)
     pop_svs = pd.read_csv(pop_svs, sep="\t")
+    # pad population SV insertion calls to account for uncertainty in position
+    pop_svs.loc[pop_svs['SVTYPE'] == 'INS', 'POS'] -= 1 
+    pop_svs.loc[pop_svs['SVTYPE'] == 'INS', 'END'] += 1    
     pop_svs_bed = BedTool.from_dataframe(pop_svs)
     intersect = annotsv_bed.intersect(
         pop_svs_bed, wa=True, wb=True, F=0.5, f=0.5


### PR DESCRIPTION
Add one on either side of population insertions (POS-1, END+1) i.e CoLoRSdb, gnomAD, C4R when comparing against sample SVs to account for uncertainty in position. 