### PR TITLE
De-duplicate HPO terms in SV report and fix HPO/OMIM annos in repeat outlier report

### DIFF
--- a/scripts/annotate_SVs.py
+++ b/scripts/annotate_SVs.py
@@ -159,7 +159,8 @@ def add_hpo(hpo, gene):
                 term = term.replace("; ", ";").split(";")
                 term = list(set(term))
                 for t in term:
-                    terms.append(t)
+                    if t not in terms:
+                        terms.append(t)
             except IndexError:
                 pass
     if len(terms) == 0:


### PR DESCRIPTION
For repeat outlier report, add HPO terms and OMIM phenotypes by Ensembl gene ID before aggregating report by gene (i.e. while there is still one row per gene). 