### PR TITLE
Remove long sample name suffixes

### DIFF
--- a/scripts/annotate_repeat_outliers.py
+++ b/scripts/annotate_repeat_outliers.py
@@ -398,35 +398,16 @@ def main(
     for col in ["gene_name", "gene_id", "gene_biotype", "Feature"]:
         hits_gene_omim[col] = hits_gene_omim[col].apply(lambda genes: gene_set(genes))
 
-    # shorten sample names (e.g. remove .m84090_240207_191948_s1.hifi_reads.bc2013.KL.GRCh38.aligned.haplotagged.trgt.sorted)
-    if "haplotagged" in al_cols[0]:
-        new_al_cols = []
-        for col in al_cols:
-            new_col = col.split(".")[0]
-            new_col = new_col + "_allele_len"
-            new_al_cols.append(new_col)
-            hits_gene_omim.rename({col: new_col}, inplace=True, axis=1)
-
-        new_z_score_cols = []
-        for col in z_score_cols:
-            new_col = col.split(".")[0]
-            new_col = new_col + "_z_score_len"
-            new_z_score_cols.append(new_col)
-            hits_gene_omim.rename({col: new_col}, inplace=True, axis=1)
-    else:
-        new_al_cols = al_cols
-        new_z_score_cols = z_score_cols
-
     am_cols = [col for col in hits_gene_omim.columns if "AM" in col]
     mp_cols = [col for col in hits_gene_omim.columns if "MP" in col]
 
     hits_gene_omim = hits_gene_omim[
         ["Chromosome", "Start", "End", "trid", "gene_name", "gene_id", "gene_biotype"]
-        + ["OMIM_phenotype", "HPO"]
+        + ["omim_phenotype","omim_inheritance", "HPO"]
         + constraint_cols
         + ["Feature", "control_range", "cutoff", "max_z_score_len", "num_samples"]
-        + new_al_cols
-        + new_z_score_cols
+        + al_cols
+        + z_score_cols
         + am_cols
         + mp_cols
     ]

--- a/scripts/find_repeat_outliers.py
+++ b/scripts/find_repeat_outliers.py
@@ -268,6 +268,9 @@ def main(cases, dist, output_file):
         {"range_long": "control_range", "cutoff_long": "cutoff"}, inplace=True, axis=1
     )
     merged_cat = pd.concat([merged_short, merged_long], axis=0)
+    
+    # shorten sample names (e.g. remove .m84090_240207_191948_s1.hifi_reads.bc2013.KL.GRCh38.aligned.haplotagged.trgt.sorted)
+    merged_cat["sample"] = merged_cat["sample"].apply(lambda x: x.split('.')[0])
 
     # remove unnecessary columns
     merged_cat = merged_cat[


### PR DESCRIPTION
Sample names in TRGT VCFs generated by TCAG can have long suffixes (e.g. .m84090_240207_191948_s1.hifi_reads.bc2013.KL.GRCh38.aligned.haplotagged.trgt.sorted), so remove these from the outliers file (note to self: maybe better to remove these from the allele db upstream). 