### PR TITLE
Add C4R outlier counts

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -60,4 +60,5 @@ trgt:
   gnomad_constraint: "/hpf/largeprojects/ccmbio/ccmmarvin_shared/pacbio_longread_pilot_phase_1/TRGT/proband_only_workflow/annotations/gnomad.v4.0.constraint_metrics.tsv"
   omim_path: "/hpf/largeprojects/ccmbio/ccmmarvin_shared/pacbio_longread_pilot_phase_1/TRGT/proband_only_workflow/annotations"
   control_alleles: "/hpf/largeprojects/ccmbio/mcouse/pacbio_report_dev/results/create_cmh_allele_db/repeat_outliers/allele_db/CMH.trgt.v0.5.0.alleles.1436.samples.20240624.tsv"
+  C4R_outliers: "/hpf/largeprojects/ccmbio/ccmmarvin_shared/pacbio_longread_pilot_phase_2/results/C4R_all_outliers_batch/outliers/aggregated_outliers_2024-09-11.csv"
 

--- a/rules/outlier_expansions.smk
+++ b/rules/outlier_expansions.smk
@@ -54,7 +54,8 @@ rule annotate_repeat_outliers:
       genes = config["trgt"]["ensembl_gtf"],
       OMIM = config["trgt"]["omim_path"],
       HPO = config["run"]["hpo"] if config["run"]["hpo"] else "none",
-      constraint = config["trgt"]["gnomad_constraint"]
+      constraint = config["trgt"]["gnomad_constraint"],
+      c4r_outliers = config["trgt"]["C4R_outliers"]
     resources:
         mem_mb = 20000
     conda: 
@@ -74,7 +75,8 @@ rule annotate_repeat_outliers:
                 --ensembl_gtf {params.genes} \
                 --gnomad_constraint {params.constraint} \
                 --OMIM_path {params.OMIM} \
-                --hpo {params.HPO}) > {log} 2>&1
+                --hpo {params.HPO} \
+                --c4r_outliers {params.c4r_outliers}) > {log} 2>&1
         fi
         """
           


### PR DESCRIPTION
I ran the tandem repeat expansion workflow for all C4R PacBio genomes (138 samples) against the CMH TRGT control database, and then calculated the number of outliers for at each tandem repeat locus. These are now added as two new columns in the report, `C4R_outlier_count` and `C4R_outlier_samples`. 