### PR TITLE
Add clinvar conflicting status

### DIFF
--- a/scripts/cre/cre.gemini2txt.vcf2db.sh
+++ b/scripts/cre/cre.gemini2txt.vcf2db.sh
@@ -66,8 +66,8 @@ sQuery="select \
         dp as Depth,\
         qual as Quality,\
         gene as Gene,\
-		COALESCE(clinvar_pathogenic, '') || COALESCE( ';' || NULLIF(clinvar_sig,''), '') as Clinvar, \
-        clinvar_status as Clinvar_status, \
+        COALESCE(clinvar_pathogenic, '') || COALESCE( ';' || NULLIF(clinvar_sig,''), '') || COALESCE( ';' || NULLIF(clinvar_sig_conf,''), '') as Clinvar, \
+	clinvar_status as Clinvar_status, \
         ensembl_gene_id as Ensembl_gene_id,\
         transcript as Ensembl_transcript_id,\
         aa_length as AA_position,\

--- a/vcfanno/pacbio.vcfanno.conf
+++ b/vcfanno/pacbio.vcfanno.conf
@@ -56,9 +56,9 @@ ops=["concat"]
 
 [[annotation]]
 file="clinvar.vcf.gz"
-fields=["CLNSIG","CLNREVSTAT"]
-names=["clinvar_pathogenic", "clinvar_status"]
-ops=["concat", "concat"]
+fields=["CLNSIG","CLNREVSTAT", "CLNSIGCONF"]
+names=["clinvar_pathogenic", "clinvar_status", "clinvar_sig_conf"]
+ops=["concat", "concat", "concat"]
                     
 # convert 5 to 'pathogenic', 255 to 'unknown', etc.
 [[postannotation]]


### PR DESCRIPTION
Add details of ClinVar conflicting status using the CLNSIGCONF field in the ClinVar VCF. For example, instead of just annotating a variant as `Conflicting_classifications_of_pathogenicity` it would be annotated as `Conflicting_classifications_of_pathogenicity;Uncertain_significance(2)|Likely_benign(3)`.