### PR TITLE
Workflow for calling and annotating methylation outliers

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@ crg2-pacbio takes as input the following VCFs output by [PacBio's WGS pipeline](
 - [TRGT](https://github.com/PacificBiosciences/trgt) VCFs, one per family member
 - aligned BAM files for each sample
 
-How to run the pipeline
+crg2-pacbio also has a module for identifying, filtering, and annotation methylation outliers, see 'Methylation outlier report' below.
+
+## How to run the pipeline
 1. Make a folder in a directory with sufficient space. Copy over the template files crg2-pacbio/samples.tsv, crg2-pacbio/units.tsv, crg2-pacbio/config.yaml, crg2-pacbio/crg2-pacbio.sh, crg2-pacbio/slurm_profile/slurm-config.yaml.  Note that 'slurm-config.yaml' is for submitting each rule as cluster jobs, so ignore this if not running on cluster.
 ```
 mkdir NA12878
@@ -54,12 +56,12 @@ snakemake --use-conda -s ${SF} --cores 4 --conda-prefix ${CP} --configfile ${CON
 
 ```
 
-Small variant annotation and report: small_variants/coding/{family}/{family}.wes.regular.{date}.csv
+## Small variant annotation and report: small_variants/coding/{family}/{family}.wes.regular.{date}.csv
 - annotate variants with [VEP](https://useast.ensembl.org/info/docs/tools/vep/index.html) and [vcfanno](https://github.com/brentp/vcfanno)
 - generate a [gemini](https://github.com/arq5x/gemini) variant database
 - generate a rare (less than 1% maximum gnomAD population AF) variant report with medium to high impact variants. Report generation scripts are derived from [cre](https://github.com/ccmbioinfo/cre), but copied to this repo for convenience. Report details are described [here](https://sickkidsca.sharepoint.com/:w:/r/sites/thecenterforcomputationalmedicineworkspace/_layouts/15/Doc.aspx?sourcedoc=%7B7E4D3F4D-D83F-474C-A9CB-F59C2EB05C8A%7D&file=SNV_indel_report_November_2021.docx&action=default&mobileredirect=true); additional columns included are allele frequencies and counts from the [CoLoRSDB cohort](https://zenodo.org/records/11511513).
 
-Small variant panel report: small_variants/panel/{family}/{family}.wgs.regular.{date}.csv, small_variants/panel-flank/{family}/{family}.wgs.regular.{date}.csv
+## Small variant panel report: small_variants/panel/{family}/{family}.wgs.regular.{date}.csv, small_variants/panel-flank/{family}/{family}.wgs.regular.{date}.csv
 - The annotation pipeline is the same as above, but only variants in a gene panel are considered. The panel report includes variants of any impact (i.e. it includes non-coding variants and intronic variants).
 - To generate a gene panel from an HPO text file exported from PhenomeCentral or G4RD, add the HPO filepath to `config["run"]["hpo"]`.
 - The first time you run the pipeline, you will also need to generate Ensembl and RefSeq gene files as well as an HGNC gene mapping file.
@@ -70,27 +72,46 @@ Small variant panel report: small_variants/panel/{family}/{family}.wgs.regular.{
 - Add the paths to the output files, Homo_sapiens.GRCh38.112.gtf_subset.csv and GRCh38_latest_genomic.gff_subset.csv, to the `config["gene"]["ensembl"]` and `config["gene"]["refseq"]` fields.
 - You will also need the HGNC alias file: download this from https://www.genenames.org/download/custom/ using the default fields. Add the path this file to `config["gene"]["hgnc"]`.
 
-Structural variant annotation and report: sv/{family}.pbsv.{date}.csv
+## Structural variant annotation and report: sv/{family}.pbsv.{date}.csv
 - annotate variants using [SnpEFF](https://github.com/pcingola/SnpEff) and [AnnotSV](https://github.com/lgmgeo/AnnotSV)
 - filter out variants under 50bp
 - annotate SVs with [custom Python script](https://github.com/ccmbioinfo/crg2-pacbio/blob/master/scripts/annotate_SVs.py)
 - a description of the report and fields can be found [here](https://sickkidsca.sharepoint.com/:w:/r/sites/thecenterforcomputationalmedicineworkspace/_layouts/15/Doc.aspx?sourcedoc=%7B531618A5-B617-4444-B496-5A9D239C4B91%7D&file=PacBio_SV_report.docx&action=default&mobileredirect=true)
 
-Repeat expansion outlier report: repeat_outliers/{family}.repeat.outliers.annotated.csv
+## Repeat expansion outlier report: repeat_outliers/{family}.repeat.outliers.annotated.csv
 - TRGT must have previously been run on each sample against the [937,122](https://zenodo.org/record/7987365#.ZHY9TOzMJAc) repeats originally released by the Genome in a Bottle tandem repeat benchmarking project
 - this module is derived from the [find-outlier-expansions workflow](https://github.com/tandem-repeat-workflows/find-outlier-expansions/blob/main/find-outlier-expansions.ipynb) developed by Egor Dolzhenko (PacBio), Adam English (Baylor College of Medicine), Tom Mokveld (PacBio), Giulia Del Gobbo (CHEO), and Madeline Couse (SickKids)
 - construct a repeat database from 98 HPRC samples and the individuals from the family of interest
 - identify repeats with outlying size in family members
 - annnotate repeat outliers with [custom Python script](https://github.com/ccmbioinfo/crg2-pacbio/blob/master/scripts/annotate_repeat_outliers.py)
 
-De novo tandem repeat variant report: TRGT_denovo/{family}_{child}.TRGT.denovo.annotated.csv
+## De novo tandem repeat variant report: TRGT_denovo/{family}_{child}.TRGT.denovo.annotated.csv
 - identify de novo tandem repeats in probands using [TRGT-denovo](https://github.com/PacificBiosciences/trgt-denovo) v0.2.0
 - note that the `trgt_vcf_dir` must contain the TRGT spanning BAMs to successfully run the denovo tandem repeat report
 - filter annotate de novo repeats with [custom Python script](https://github.com/ccmbioinfo/crg2-pacbio/blob/master/scripts/annotate_denovo_repeats.py)
 
-Pathogenic repeat loci report: pathogenic_repeats/{family}.known.path.str.loci.csv
+## Pathogenic repeat loci report: pathogenic_repeats/{family}.known.path.str.loci.csv
 - genotype repeats per-sample using TRGTv1.0.0 against the [pathogenic repeat loci BED file](https://github.com/PacificBiosciences/trgt/blob/main/repeats/pathogenic_repeats.hg38.bed) provided by TRGT (the GIAB 937,122 catalog only contains 50/56 loci). Note that TRGT requires BAMs; these must be added to the samples.tsv file
 - merge sample VCFs into multi-sample family VCF
 - annotate repeat loci with [custom Python script](https://github.com/ccmbioinfo/crg2-pacbio/blob/master/scripts/annotate_path_str_loci.py)
 
+## Methylation outlier report: methylation_outliers/{family}_{sample}.annotated.outliers.{date}.csv
+The methylation outlier workflow uses [pb-cpg-tools](https://github.com/PacificBiosciences/pb-CpG-tools) to extract CpG sites from the BAM files (coverage threshold of 5x) and [Methbat](https://github.com/PacificBiosciences/MethBat) to identify haplotype-specific methylation outliers in one sample against a background of samples. You must list both the case sample and the control samples in the `samples.tsv` file, specifying the 'case_or_control' field as 'case' for the case sample and 'control' for the control samples. There must only be one case sample, and ideally as many controls samples as possible. 
+Example samples.tsv for methylation outlier analysis:
+```
+sample	BAM	case_or_control
+01	/path/to/01.GRCh38.aligned.haplotagged.bam	case
+02	/path/to/02.GRCh38.aligned.haplotagged.bam	control
+03	/path/to/03.GRCh38.aligned.haplotagged.bam	control
+04	/path/to/04.GRCh38.aligned.haplotagged.bam	control
+05	/path/to/05.GRCh38.aligned.haplotagged.bam	control
+(and so on)
+```
+The workflow is as follows:
+- extract CpG sites from BAMs using [pb-cpg-tools](https://github.com/PacificBiosciences/pb-CpG-tools)
+- generate MethBat profiles for each sample using Methbat
+- build a background profile using the control samples using MethBat
+- identify methylation outliers using MethBat
+- annotate methylation outliers with [custom Python script](https://github.com/ccmbioinfo/crg2-pacbio/blob/master/scripts/annotate_methylation_outliers.py)
 
+To run the methylation outlier workflow, follow the instructions above for running the pipeline, but make sure your samples.tsv is configured for methylation outlier analysis, and use the `methylation_outliers.sh` job script instead of `crg2-pacbio.sh`.

--- a/config.yaml
+++ b/config.yaml
@@ -19,6 +19,7 @@ tools:
   annotSV: "/hpf/largeprojects/ccmbio/ccmmarvin_shared/pacbio_longread_pilot_phase_1/annotate_SV/tools/AnnotSV-3.1.1"
   trgt: "/hpf/largeprojects/ccmbio/ccmmarvin_shared/pacbio_longread_pilot_phase_2/tools/TRGTv1.0.0/trgt"
   trgt-denovo: "/hpf/largeprojects/ccmbio/ccmmarvin_shared/pacbio_longread_pilot_phase_2/tools/trgt-denovo-v0.2.0/trgt-denovo"
+  mosdepth: "/hpf/largeprojects/ccmbio/ccmmarvin_shared/pacbio_longread_pilot_phase_2/tools/mosdepth-0.3.11/mosdepth"
 
 ref:
   name: GRCh38.86
@@ -52,6 +53,14 @@ annotation:
       trgt_catalog: "/hpf/largeprojects/ccmbio/ccmmarvin_shared/pacbio_longread_pilot_phase_2/tools/TRGTv1.0.0/repeats/pathogenic_repeats.hg38.bed"
       disease_thresholds: "/hpf/largeprojects/ccm_dccforge/dccdipg/Common/annotation/ExpansionHunter/tandem_repeat_disease_loci_v1.1.tsv"
 
+methbat:
+  regions: "/hpf/largeprojects/ccmbio/ccmmarvin_shared/pacbio_longread_pilot_phase_2/code/scripts/methbat/regions/hg38_200bp_tiles.tsv"
+  regions_bed: "/hpf/largeprojects/ccmbio/ccmmarvin_shared/pacbio_longread_pilot_phase_2/code/scripts/methbat/regions/hg38_200bp_tiles.bed"
+
+pbcpgtools:
+  binary: "/hpf/largeprojects/ccmbio/ccmmarvin_shared/pacbio_longread_pilot_phase_2/tools/pb-CpG-tools-v2.3.2-x86_64-unknown-linux-gnu/bin/aligned_bam_to_cpg_scores"
+  model: "/hpf/largeprojects/ccmbio/ccmmarvin_shared/pacbio_longread_pilot_phase_2/tools/pb-CpG-tools-v2.3.2-x86_64-unknown-linux-gnu/models/pileup_calling_model.v1.tflite"
+
 params:
   snpeff:
     java_opts: "-Xms750m -Xmx20g"
@@ -64,4 +73,3 @@ trgt:
   control_alleles: "/hpf/largeprojects/ccmbio/ccmmarvin_shared/pacbio_longread_pilot_phase_2/code/scripts/trgt/CMH.alleles.distribution.tsv"
   C4R_outliers: "/hpf/largeprojects/ccmbio/ccmmarvin_shared/pacbio_longread_pilot_phase_2/results/C4R_all_outliers_batch/outliers/aggregated_outliers_2024-10-09.csv"
   adotto_repeats: "/hpf/largeprojects/ccmbio/ccmmarvin_shared/pacbio_longread_pilot_phase_1/TRGT/repeat_definitions/adotto_repeats.hg38.bed"
-

--- a/envs/methbat.yaml
+++ b/envs/methbat.yaml
@@ -1,0 +1,6 @@
+channels:
+  - conda-forge
+  - bioconda
+  - defaults
+dependencies:
+  - methbat=0.13.3

--- a/methylation_outliers.sh
+++ b/methylation_outliers.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+#SBATCH --job-name=meth_outliers
+#SBATCH --time=75:00:00
+#SBATCH --ntasks-per-node=1
+#SBATCH --mem=4G
+#SBATCH --output=%x-%j.out
+
+SF=~/crg2-pacbio/Snakefile/methylation_outliers.smk
+CP="/hpf/largeprojects/ccm_dccforge/dccdipg/Common/snakemake"
+SLURM=~/crg2-pacbio/slurm_profile/
+CONFIG="config.yaml"
+
+source /hpf/largeprojects/ccm_dccforge/dccdipg/Common/anaconda3/etc/profile.d/conda.sh
+conda activate snakemake
+
+snakemake --use-conda -s ${SF} --cores 4 --conda-prefix ${CP} --configfile ${CONFIG} --profile ${SLURM}

--- a/methylation_outliers.smk
+++ b/methylation_outliers.smk
@@ -3,7 +3,9 @@ include: "rules/methbat.smk"
 
 
 samples = pd.read_table(config["run"]["samples"], dtype=str).set_index("sample", drop=False)
+case = samples[samples["case_or_control"] == "case"]
+controls = samples[samples["case_or_control"] == "control"]
 
 rule all:
     input:
-       expand("methbat/outliers/{sample}.annotated.outliers.csv", sample=samples.index)
+       expand("methbat/outliers/{sample}.annotated.outliers.csv", sample=case.index)

--- a/methylation_outliers.smk
+++ b/methylation_outliers.smk
@@ -1,0 +1,9 @@
+include: "rules/common.smk"
+include: "rules/methbat.smk"
+
+
+samples = pd.read_table(config["run"]["samples"], dtype=str).set_index("sample", drop=False)
+
+rule all:
+    input:
+       expand("methbat/outliers/{sample}.annotated.outliers.csv", sample=samples.index)

--- a/rules/common.smk
+++ b/rules/common.smk
@@ -13,6 +13,8 @@ report: "../report/workflow.rst"
 #validate(config, schema="../schemas/config.schema.yaml")
 
 samples = pd.read_table(config["run"]["samples"], dtype=str).set_index("sample", drop=False)
+case = samples[samples["case_or_control"] == "case"]
+controls = samples[samples["case_or_control"] == "control"]
 #validate(samples, schema="../schemas/samples.schema.yaml")
 
 units = pd.read_table(config["run"]["units"], dtype=str).set_index(["family"], drop=False)
@@ -72,3 +74,6 @@ def get_bam(wildcards):
     bam = samples.loc[wildcards.sample, "BAM"]
 
     return bam
+
+def get_methbat_profiles(wildcards):
+    return [f"methbat/profiles/{sample}.profile.tsv" for sample in controls.index]

--- a/rules/methbat.smk
+++ b/rules/methbat.smk
@@ -127,7 +127,7 @@ rule methbat_annotate_outliers:
         mem_mb = 40000
     shell:
         """
-        if [ -f {params.hpo} ]; then
+        if [ -z {params.hpo} ]; then
                 python3 ../scripts/annotate_methylation_outliers.py \
                 --outliers {input.outliers} \
                 --output_file {output} \

--- a/rules/methbat.smk
+++ b/rules/methbat.smk
@@ -102,8 +102,9 @@ rule methbat_call_outliers:
         mem_mb = 40000
     shell:
         """
+        input=`echo {input.meth_probs} | sed 's/.combined.bed//'`
         methbat profile \
-        --input-prefix {input.meth_probs} \
+        --input-prefix $input \
         --input-regions {input.cohort} \
         --output-region-profile {output}
         """

--- a/rules/methbat.smk
+++ b/rules/methbat.smk
@@ -1,0 +1,147 @@
+rule pbcpgtools:
+    input:
+        samples = config["trgt"]["samples"]
+    params:
+        ref = config["ref"]["genome"],
+        pbcpgtools = config["pbcpgtools"]["binary"], 
+        model = config["pbcpgtools"]["model"] 
+    output:
+        combined = "pb-cpg-tools/{sample}/{sample}.combined.bed",
+        hap1 = "pb-cpg-tools/{sample}/{sample}.hap1.bed",
+        hap2 = "pb-cpg-tools/{sample}/{sample}.hap2.bed"
+    log:
+        "logs/pbcpgtools/{sample}.log"
+    resources:
+        mem_mb = 40000,
+        threads = 8
+    shell:
+        """
+        BAM=`cat {input.samples} | grep -P "{wildcards.sample}\t" | awk '{{print $2}}'`
+        {params.pbcpgtools} \
+            --threads {resources.threads} \
+            --bam $BAM \
+            --ref {params.ref} \
+            --output-prefix pb-cpg-tools/{wildcards.sample}/{wildcards.sample} \
+            --min-mapq 1 \
+            --min-coverage 5 \
+            --model {params.model}
+        """
+
+rule mosdepth_tiles:
+    input:  
+        samples = config["trgt"]["samples"]
+    params:
+        mosdepth = config["tools"]["mosdepth"],
+        regions = config["methbat"]["regions_bed"]
+    output:
+        "mosdepth/{sample}/{sample}.regions.bed.gz"
+    log:
+        "logs/mosdepth/{sample}.log"
+    resources:
+        mem_mb = 40000,
+        threads = 8
+    shell:
+        """
+        BAM=`cat {input.samples} | grep -P "{wildcards.sample}\t" | awk '{{print $2}}'`
+        {params.mosdepth} -t {resources.threads} -b {params.regions} -n mosdepth/{wildcards.sample}/{wildcards.sample} $BAM 
+        """
+
+rule methbat_profile:
+    input: "pb-cpg-tools/{sample}/{sample}.combined.bed"
+    params: 
+        regions = config["methbat"]["regions"]
+    output: "methbat/profiles/{sample}.profile.tsv"
+    log:
+        "logs/methbat/profile/{sample}.log"
+    conda: "../envs/methbat.yaml"
+    resources:
+        mem_mb = 40000
+    shell:
+        """
+        input=`echo {input} | sed 's/.combined.bed//'`
+        methbat profile \
+        --input-prefix $input \
+        --input-regions {params.regions} \
+        --output-region-profile {output}
+        """
+
+rule methbat_build_cohort:
+    input: get_methbat_profiles,
+    output: "methbat/cohort_methylation_distributions.tsv"
+    log:
+        "logs/methbat/build_cohort.log"
+    conda: "../envs/methbat.yaml"
+    resources:
+        mem_mb = 600000
+    shell:
+        """
+        # both sequencing platforms
+        echo -e "identifier\tfilename\tlabels" > methbat/cohort_profile_paths.tsv
+        for f in methbat/profiles/*tsv
+        do
+                ID=`basename $f | cut -d'.' -f1`
+                echo -e "$ID\t$f\t" >>  methbat/cohort_profile_paths.tsv
+        done 
+
+        methbat build \
+        --input-collection  methbat/cohort_profile_paths.tsv \
+        --output-profile {output}
+        """
+
+
+rule methbat_call_outliers:
+    input:
+        meth_probs = "pb-cpg-tools/{sample}/{sample}.combined.bed",
+        cohort = "methbat/cohort_methylation_distributions.tsv"
+    output:
+        "methbat/outliers/{sample}.outliers.tsv"
+    log:
+        "logs/methbat/outliers/{sample}.log"
+    conda: "../envs/methbat.yaml"
+    resources:
+        mem_mb = 40000
+    shell:
+        """
+        methbat profile \
+        --input-prefix {input.meth_probs} \
+        --input-regions {input.cohort} \
+        --output-region-profile {output}
+        """
+
+
+rule methbat_annotate_outliers:
+    input: 
+        outliers = "methbat/outliers/{sample}.outliers.tsv",
+        coverage = "mosdepth/{sample}/{sample}.regions.bed.gz"
+    params:
+        ensembl = config["trgt"]["ensembl"],
+        gnomad_constraint = config["trgt"]["gnomad_constraint"],
+        OMIM_path = config["annotation"]["omim_path"], 
+        hpo = config["run"]["hpo"]
+    output: "methbat/outliers/{sample}.annotated.outliers.csv"
+    log:
+        "logs/methbat/annotation/{sample}.log"
+    conda: "../envs/str_sv.yaml"
+    resources:
+        mem_mb = 40000
+    shell:
+        """
+        if [ -f {params.hpo} ]; then
+                python3 ../scripts/annotate_methylation_outliers.py \
+                --outliers {input.outliers} \
+                --output_file {output} \
+                --ensembl {params.ensembl} \
+                --gnomad_constraint {params.gnomad_constraint} \
+                --OMIM_path {params.OMIM_path} \
+                --coverage {input.coverage} \
+                --hpo {params.hpo}
+        else
+            echo "HPO not found"
+            python3 ../scripts/annotate_methylation_outliers.py \
+                --outliers {input.outliers} \
+                --output_file {output} \
+                --ensembl {params.ensembl} \
+                --gnomad_constraint {params.gnomad_constraint} \
+                --OMIM_path {params.OMIM_path} \
+                --coverage {input.coverage}
+        """

--- a/scripts/annotate_methylation_outliers.py
+++ b/scripts/annotate_methylation_outliers.py
@@ -1,0 +1,362 @@
+import argparse
+from datetime import date
+import numpy as np
+import pandas as pd
+import pyranges as pr
+import sys
+from typing import Optional
+
+sys.path.insert(0, "/home/ccmmarvin/crg2-pacbio/scripts/annotation")
+
+def annotate_adjacents_tiles(chr: str, start: int, end: int, coordinates_dict: dict) -> int:
+    """determine if outlier region is adjacent to 0, one, or two outlier regions"""
+    count = 0
+    start = f"{chr}-{start}"
+    end = f"{chr}-{end}"
+    if coordinates_dict[start] > 1: 
+        count += 1
+    if coordinates_dict[end] > 1:
+        count += 1
+
+    return count 
+
+def find_closest_exon(outlier_row: pd.Series, exons: pd.DataFrame) -> pd.Series:
+    """Find the closest exon to an outlier region"""
+    # Filter exons on same chromosome
+    chrom_exons = exons[exons["Chromosome"] == outlier_row["Chromosome"]]
+    
+    if len(chrom_exons) == 0:
+        return pd.Series({
+            "closest_exon_dist": None,
+            "closest_exon_gene": None,
+            "closest_exon_start": None,
+            "closest_exon_end": None
+        })
+    
+    # Vectorized distance calculation: calculate start and end distances for all exons at once
+    # Where the start of the exon is greater than the end of the outlier, the distance is the difference between the start of the exon and the end of the outlier
+    # Where the end of the exon is less than the start of the outlier, the distance is the difference between the end of the exon and the start of the outlier
+    # Where the exon overlaps with the outlier, the distance is 0
+    start_dists = np.where(outlier_row["End"] < chrom_exons["Start"],
+                          chrom_exons["Start"] - outlier_row["End"],
+                          np.inf)
+    
+    end_dists = np.where(outlier_row["Start"] > chrom_exons["End"], 
+                         outlier_row["Start"] - chrom_exons["End"],
+                         np.inf)
+    
+    # Check for overlaps between outlier region and exons
+    # overlaps is a series of booleans
+    overlaps = ((outlier_row["Start"] <= chrom_exons["End"]) & 
+                (outlier_row["End"] >= chrom_exons["Start"]))
+    
+    # Combine all distances, using 0 for overlaps
+    distances = np.where(overlaps, 0, 
+                        np.minimum(start_dists, end_dists))
+    
+    # Find closest exon
+    min_dist_idx = np.argmin(distances)
+    closest_exon = chrom_exons.iloc[min_dist_idx]
+    
+    return pd.Series({
+        "closest_exon_dist": distances[min_dist_idx],
+        "closest_exon_gene": closest_exon["gene_name"] if pd.isna(closest_exon["gene_name"]) == False else closest_exon["gene_id"],
+        "closest_exon_start": closest_exon["Start"],
+        "closest_exon_end": closest_exon["End"]
+    })
+
+def annotate_reg_regions(outliers: pd.DataFrame, greendb: str) -> pd.DataFrame:
+    """Annotate outliers with GREENDB regulatory regions"""
+    greendb = pd.read_csv(greendb, sep="\t", compression="gzip")
+    greendb.rename(columns={"#Chromosome": "Chromosome"}, inplace=True)
+    # convert greendb and outlier dataframes to PyRanges objects and join them to find overlaps
+    greendb_pr = pr.PyRanges(greendb)
+    outliers.rename(columns={"chrom": "Chromosome", "start": "Start", "end": "End"}, inplace=True)
+    outliers_pr = pr.PyRanges(outliers)
+    outliers_pr = outliers_pr.join(greendb_pr, how="left", suffix="_greendb")
+    outliers = outliers_pr.df.drop(columns=["Start_greendb", "End_greendb", "regionID", "constrain_pct", "PhyloP100_median", "closestGene_dist", "closestProt_symbol", "closestProt_dist", "N_methods"])
+    outliers.rename(columns={"std_type": "GREENDB_reg_region", "db_source": "GREENDB_source", "closestGene_symbol": "GREENDB_closest_gene", "controlled_genes": "GREENDB_controlled_genes"}, inplace=True)
+    outliers.replace({np.nan: "."}, inplace=True)
+
+    return outliers
+
+def group_by_greendb(hits_gene: pd.DataFrame) -> pd.DataFrame:
+    """
+    One hit may be associated with multiple GREENDB features and therefore multiple rows
+    Aggregate by GREENDB and join features to remove duplicate rows
+    """
+    hits_greendb_dedup = hits_gene.groupby(["trid"]).agg(
+        {
+            "GREENDB_reg_region": ";".join,
+            "GREENDB_source": ";".join,
+            "GREENDB_closest_gene": ";".join,
+            "GREENDB_controlled_genes": ";".join,
+        }
+    )
+    # merge with original loci table
+    hits_gene = hits_gene.drop(columns=["GREENDB_reg_region", "GREENDB_source", "GREENDB_closest_gene", "GREENDB_controlled_genes"])
+    hits_greendb_merged = hits_gene.merge(hits_greendb_dedup, on=["trid"], how="left")
+    hits_greendb_merged_dedup = hits_greendb_merged.drop_duplicates(keep="first")
+
+    return hits_greendb_merged_dedup
+from annotate import (
+    annotate_genes,
+    gene_set,
+    add_constraint,
+    prepare_OMIM,
+    annotate_OMIM,
+    add_hpo,
+    group_by_gene,
+)
+
+from annotate import (
+    annotate_genes,
+    gene_set,
+    add_constraint,
+    prepare_OMIM,
+    annotate_OMIM,
+    add_hpo,
+    group_by_gene,
+)
+
+def main(
+    outliers: str,
+    out_file: str,
+    ensembl: str,
+    constraint: str,
+    omim: str,
+    coverage: Optional[str] = None,
+    hpo: Optional[str] = None
+) -> None:
+
+    print("Loading and filtering methylation outliers")
+    outliers = pd.read_csv(outliers, sep="\t")
+    try:
+        coverage = pd.read_csv(coverage, compression="gzip", sep="\t", header=None, names=["chrom", "start", "end", "cpg_ID", "mean_coverage"])
+        # annotate regions with average coverage from mosdepth
+        outliers = outliers.merge(coverage, on=["chrom", "start", "end"], how="left")
+    except:
+        print("No coverage file provided")
+  
+    try:
+        outliers["chrom"] = outliers["chrom"].str.replace("chr", "")
+    except KeyError: #cohort comparison
+        outliers.rename(columns={"#chrom": "chrom"}, inplace=True)
+        outliers["chrom"] = outliers["chrom"].str.replace("chr", "")
+
+    try:
+        outliers = outliers[(outliers["compare_label"] != "Uncategorized") & 
+                            (outliers["compare_label"] != "InsufficientData")]
+    except KeyError: # cohort comparison
+        outliers = outliers[(outliers["summary_comparison"] != "Uncategorized") & 
+                            (outliers["summary_comparison"] != "InsufficientData")]
+
+    # count number of adjacent outlier tiles
+    outliers["chr-start"] = outliers["chrom"] + "-" + outliers["start"].astype(str)
+    outliers["chr-end"] = outliers["chrom"] + "-" + outliers["end"].astype(str)
+    coordinates = outliers["chr-start"].tolist()
+    coordinates.extend(outliers["chr-end"].tolist())
+    coordinates_dict = {}
+    for coord in coordinates:
+        coordinates_dict[coord] = coordinates.count(coord)
+    outliers["adjacent_tiles"] = outliers.apply(lambda row: annotate_adjacents_tiles(row["chrom"], row["start"], row["end"], coordinates_dict), axis=1)
+
+    # convert to pyranges object
+    outliers.rename({"chrom": "Chromosome", "start": "Start", "end": "End"}, axis=1, inplace=True)
+    outliers_pr = pr.PyRanges(outliers)
+
+    # annotate outliers with Ensembl genes
+    print("Annotate against Ensembl genes")
+    gene_gr = pd.read_csv(ensembl)
+    outliers_gene = annotate_genes(outliers_pr, pr.PyRanges(gene_gr))
+
+    # annotate with closest exon
+    print("Annotate with closest exon")
+    exons = gene_gr[gene_gr["Feature"] == "exon"]
+    closest_exons = outliers_gene.apply(lambda x: find_closest_exon(x, exons), axis=1)
+    outliers_gene = pd.concat([outliers_gene, closest_exons], axis=1)
+
+
+    # annotate with gene constraint
+    print("Add gnomAD gene constraint")
+    constraint_cols = ["gene", "mane_select", "lof.oe_ci.upper", "lof.pLI"]
+    constraint = pd.read_csv(constraint, sep="\t")[constraint_cols].dropna()
+    outliers_gene = add_constraint(constraint, outliers_gene)
+
+    # annotate with OMIM
+    print("Add OMIM phenotype")
+    omim = prepare_OMIM(f"{omim}/genemap2.txt")
+    outliers_gene_omim = annotate_OMIM(outliers_gene, omim)
+
+    # annotate with HPO terms
+    try:
+        print("Add HPO terms")
+        hpo = pd.read_csv(hpo, sep="\t")
+        outliers_gene_omim = add_hpo(hpo, outliers_gene_omim)
+    except:
+        print("No HPO terms supplied")
+        outliers_gene_omim["HPO"] = ""
+
+    # add a trid column so dataframe is compatible with group_by_gene and group_by_greendb functions
+    outliers_gene_omim["trid"] = outliers_gene_omim.apply(lambda x: x["Chromosome"] + str(x["Start"]) + str(x["End"]), axis=1)
+    print(outliers_gene_omim.columns)
+    outliers_gene_omim = group_by_gene(outliers_gene_omim)
+
+    # annotate with GREENDB
+    print("Add GREENDB regulatory regions")
+    outliers_gene_omim = annotate_reg_regions(outliers_gene_omim, "/hpf/largeprojects/ccmbio/nhanafi/c4r/downloads/databases/GRCh38_GREEN-DB.bed.gz")
+    print(outliers_gene_omim.columns)
+    outliers_gene_omim = group_by_greendb(outliers_gene_omim)
+
+
+    # add a maximum delta column
+    outliers_gene_omim['max_abs_meth_delta_zscore'] = outliers_gene_omim.apply(
+        lambda x: np.abs(x['mean_abs_meth_delta_zscore']) if pd.isna(x['mean_combined_methyl_zscore'])
+        else np.abs(x['mean_combined_methyl_zscore']) if pd.isna(x['mean_abs_meth_delta_zscore'])
+        else np.maximum(np.abs(x['mean_abs_meth_delta_zscore']), np.abs(x['mean_combined_methyl_zscore'])),
+        axis=1
+    )
+
+    # add a maximum number of CpGs column
+    outliers_gene_omim['max_num_cpgs'] = outliers_gene_omim[['num_phased_cpgs', 'num_unphased_cpgs']].max(axis=1)
+    
+    # column cleanup
+    for col in ["gene_name", "gene_id", "gene_biotype", "Feature"]:
+        outliers_gene_omim[col] = outliers_gene_omim[col].apply(lambda genes: gene_set(genes))
+    
+
+    outliers_gene_omim = outliers_gene_omim.rename(
+        columns={
+            "Feature": "feature",
+            "Segdup": "segdup",
+            "Chromosome": "CHROM",
+            "Start": "POS",
+            "End": "END",
+            "gene": "gnomad_constraint_gene",
+        }
+    )
+
+    outliers_gene_omim.replace({"-1": ".", "nan": "."}, inplace=True)
+
+
+    columns = [
+        "CHROM", "POS", "END", "adjacent_tiles", "summary_label", "compare_label", 
+        "gene_name", "gene_id", "gene_biotype", "closest_exon_gene", "omim_phenotype", "omim_inheritance", 
+        "HPO", "gnomad_constraint_gene", "lof.oe_ci.upper", "lof.pLI", "feature",
+        "category_pop_count", "category_pop_freq", "asm_fishers_pvalue",
+        "mean_hap1_methyl", "mean_hap2_methyl", "mean_meth_delta",
+        "mean_abs_meth_delta_zscore", "mean_combined_methyl",
+        "mean_combined_methyl_zscore", "max_abs_meth_delta_zscore", "num_phased_cpgs", "num_partial_cpgs",
+        "num_unphased_cpgs", "max_num_cpgs", "mean_coverage", "GREENDB_reg_region", "GREENDB_source", "GREENDB_closest_gene", "GREENDB_controlled_genes"
+    ]
+
+    try:
+        outliers_gene_omim = outliers_gene_omim[columns]
+        outliers_gene_omim = outliers_gene_omim.sort_values(by="max_abs_meth_delta_zscore", ascending=False)
+    except KeyError:
+    #     columns = [
+    #         "CHROM", "POS", "END", "baseline_category", "compare_category", "summary_comparison",
+    #         "gene_name", "gene_id", "gene_biotype", "omim_phenotype", "omim_inheritance", 
+    #         "HPO", "gnomad_constraint_gene", "lof.oe_ci.upper", "lof.pLI", "feature",
+    #         "zscore_avg_abs_meth_deltas",
+    #         "delta_avg_abs_meth_deltas",
+    #         "baseline_num_phased",
+    #         "compare_num_phased",
+    #         "zscore_avg_combined_methyls",
+    #         "delta_avg_combined_methyls", 
+    #         "baseline_num_samples",
+    #         "compare_num_samples"
+    # ]
+        columns = [
+            "CHROM", "POS", "END", "summary_label", "compare_label", 
+            "gene_name", "gene_id", "gene_biotype", "omim_phenotype", "omim_inheritance",  "gnomad_constraint_gene", "lof.oe_ci.upper", "lof.pLI", "feature",
+            "category_pop_count", "category_pop_freq", "asm_fishers_pvalue",
+            "mean_hap1_methyl", "mean_hap2_methyl", "mean_meth_delta",
+            "mean_abs_meth_delta_zscore", "mean_combined_methyl",
+            "mean_combined_methyl_zscore", "max_abs_meth_delta_zscore", "num_phased_cpgs", "num_partial_cpgs",
+            "num_unphased_cpgs", "max_num_cpgs",  "GREENDB_reg_region", "GREENDB_source", "GREENDB_closest_gene", "GREENDB_controlled_genes"
+        ]
+        outliers_gene_omim = outliers_gene_omim[columns]
+        outliers_gene_omim = outliers_gene_omim.sort_values(by="max_abs_meth_delta_zscore", ascending=False)
+
+
+    # write to file
+    today = date.today()
+    today = today.strftime("%Y-%m-%d")
+    out_file = out_file.replace(".csv", "")
+    outliers_gene_omim = outliers_gene_omim.drop_duplicates()
+    print(f"Writing to file {out_file}.{today}.csv")
+    outliers_gene_omim.to_csv(f"{out_file}.{today}.csv", index=False)
+
+
+
+if __name__ == "__main__":
+    # if running from the command-line
+    description = "Annotate repeat outliers with Ensembl genes, gnomAD constraint metrics, OMIM phenotypes, and HPO terms"
+    parser = argparse.ArgumentParser(description=description)
+    parser.add_argument(
+        "--outliers",
+        type=str,
+        required=True,
+        help="Methylation outliers called by MethBat",
+    )
+    parser.add_argument(
+        "--output_file",
+        type=str,
+        required=True,
+        help="Output filepath",
+    )
+    parser.add_argument(
+        "--ensembl",
+        type=str,
+        required=True,
+        help="Path to Ensembl gene CSV",
+    )
+    parser.add_argument(
+        "--gnomad_constraint",
+        type=str,
+        required=True,
+        help="Path to gnomAD constraint file",
+    )
+    parser.add_argument(
+        "--OMIM_path",
+        type=str,
+        required=True,
+        help="Path to directory containing OMIM mim2gene and morbidmap files",
+    )
+    parser.add_argument(
+        "--coverage",
+        type=str,
+        help="mosdepth regions.bed.gz file for CpG islands",
+    )
+    parser.add_argument(
+        "--hpo",
+        type=str,
+        help="Path to HPO terms file",
+    )
+
+    args = parser.parse_args()
+    print("Annotating methylation outliers...")
+    if args.coverage:
+        main(
+            args.outliers,
+            args.output_file,
+            args.ensembl,
+            args.gnomad_constraint,
+            args.OMIM_path,
+            args.coverage,
+            args.hpo,
+        )
+    else:
+        print("Cohort comparison provided, omitting HPO and coverage annotations")
+        main(
+            args.outliers,
+            args.output_file,
+            args.ensembl,
+            args.gnomad_constraint,
+            args.OMIM_path,
+        )
+
+
+
+

--- a/scripts/annotate_methylation_outliers.py
+++ b/scripts/annotate_methylation_outliers.py
@@ -236,7 +236,18 @@ def main(
         }
     )
 
-    outliers_gene_omim.replace({"-1": ".", "nan": "."}, inplace=True)
+    # round numeric columns 
+    outliers_gene_omim["asm_fishers_pvalue"] = outliers_gene_omim["asm_fishers_pvalue"].round(7)
+    # these numeric columns have some missing values encoded as "."
+    for col in ["mean_hap1_methyl", "mean_hap2_methyl", "mean_meth_delta", "mean_abs_meth_delta_zscore"]:
+        outliers_gene_omim[col] = outliers_gene_omim[col].replace(".", np.nan)
+    numeric_cols = [
+        "mean_hap1_methyl", "mean_hap2_methyl", "mean_meth_delta",
+        "mean_abs_meth_delta_zscore", "mean_combined_methyl", "mean_combined_methyl_zscore", "max_abs_meth_delta_zscore"
+    ]
+    outliers_gene_omim[numeric_cols] = outliers_gene_omim[numeric_cols].round(2)
+
+    outliers_gene_omim.replace({"-1": ".", "nan": ".", np.nan: "."}, inplace=True)
 
 
     columns = [

--- a/scripts/annotate_methylation_outliers.py
+++ b/scripts/annotate_methylation_outliers.py
@@ -241,7 +241,7 @@ def main(
     for col in ["mean_hap1_methyl", "mean_hap2_methyl", "mean_meth_delta", "mean_abs_meth_delta_zscore"]:
         outliers_gene_omim[col] = outliers_gene_omim[col].replace(".", np.nan)
     numeric_cols = [
-        "mean_hap1_methyl", "mean_hap2_methyl", "mean_meth_delta",
+        "category_pop_freq","mean_hap1_methyl", "mean_hap2_methyl", "mean_meth_delta",
         "mean_abs_meth_delta_zscore", "mean_combined_methyl", "mean_combined_methyl_zscore", "max_abs_meth_delta_zscore"
     ]
     outliers_gene_omim[numeric_cols] = outliers_gene_omim[numeric_cols].round(2)

--- a/slurm_profile/slurm-config.yaml
+++ b/slurm_profile/slurm-config.yaml
@@ -29,5 +29,6 @@ allsnvreport:
 vcf2db:
   time: "50:00:00"
 
-
+methbat_build_cohort:
+  mem: "600G"
 


### PR DESCRIPTION
This workflow does the following

- Call methylation probabilities for each sample in `samples.tsv` using pb-cpg-tools with a default coverage threshold of 5
- Use `methbat profile` to calculate the haplotype-specific average methylation probabilities over 200 base tiles across the genome for each sample listed in `samples.tsv` using the output from pb-cpg-tools
- Calculate population/background methylation distributions in each genome tile using `methbat build`
- Determine outlier methylation tiles in each sample compared to the population/background using `methbat profile` 
- Annotate methylation outliers using `scripts/annotate_methylation_outliers.py`

TO DO: Add a column in `samples.tsv` to specify if a sample is a case or control, so that sample can be excluded from the background 