### PR TITLE
Expand pathogenic STR catalog

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -51,8 +51,8 @@ annotation:
       anno_path: "/hpf/largeprojects/ccmbio/ccmmarvin_shared/pacbio_longread_pilot_phase_1/annotate_SV/annotations/"
       colorsdb: "/hpf/largeprojects/ccmbio/ccmmarvin_shared/pacbio_longread_pilot_phase_2/data/CoLoRSdb/v1.1.0/CoLoRSdb.GRCh38.v1.1.0.pbsv.jasmine.bed"
   pathogenic_repeats:
-      trgt_catalog: "/hpf/largeprojects/ccmbio/ccmmarvin_shared/pacbio_longread_pilot_phase_2/tools/TRGTv1.0.0/repeats/pathogenic_repeats.hg38.bed"
-      disease_thresholds: "/hpf/largeprojects/ccm_dccforge/dccdipg/Common/annotation/ExpansionHunter/tandem_repeat_disease_loci_v1.1.tsv"
+      trgt_catalog: "/hpf/largeprojects/ccmbio/ccmmarvin_shared/pacbio_longread_pilot_phase_1/TRGT/repeat_definitions/STRchive-disease-loci.hg38.TRGT.expanded.bed"
+      disease_thresholds: "/hpf/largeprojects/ccm_dccforge/dccdipg/Common/annotation/ExpansionHunter/tandem_repeat_disease_loci_v1.1.3.tsv"
 
 methbat:
   regions: "/hpf/largeprojects/ccmbio/ccmmarvin_shared/pacbio_longread_pilot_phase_2/code/scripts/methbat/regions/hg38_200bp_tiles.tsv"

--- a/scripts/annotate_path_str_loci.py
+++ b/scripts/annotate_path_str_loci.py
@@ -64,7 +64,7 @@ def is_disease(motif_count, gene, threshold):
             if count == ".":
                 continue
             elif gene == "VWA1":
-                if count == 1 or count == 3: # 2 copies is benign as per STRchive 
+                if count != 2: # 2 copies is benign as per STRchive 
                     is_disease = True
             elif count >= int(threshold):
                 is_disease = True


### PR DESCRIPTION
Updated report to use [additional loci from STRchive](https://strchive.org/_astro/STRchive-disease-loci.hg38.TRGT.B2FLLAlV.bed) as well as [disease thresholds reported by STRchive](https://strchive.org/_astro/STRchive-disease-loci.hg38.CE2vK2zA.bed). 

I made the following changes: 
- Incorporated additional loci from STRchive. Previously we genotyped 56 loci; now we will report 77 loci.
- The Jupyter notebook to generate the disease thresholds file is at /hpf/largeprojects/ccm_dccforge/dccdipg/Common/annotation/ExpansionHunter/update_thresholds.ipynb. 
- Updated scripts to use disease thresholds from STRchive. 
- Where all family members are homozygous reference at a locus, the ALT allele now reads 'homozygous_ref'