### PR TITLE
Calculate and annotate LPS, add more annotations

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -21,7 +21,7 @@ tools:
   trgt: "/hpf/largeprojects/ccmbio/ccmmarvin_shared/pacbio_longread_pilot_phase_2/tools/TRGTv1.1.0/trgt-v1.1.0-x86_64-unknown-linux-gnu/trgt"
   trgt-denovo: "/hpf/largeprojects/ccmbio/ccmmarvin_shared/pacbio_longread_pilot_phase_2/tools/trgt-denovo-v0.2.0/trgt-denovo"
   mosdepth: "/hpf/largeprojects/ccmbio/ccmmarvin_shared/pacbio_longread_pilot_phase_2/tools/mosdepth-0.3.11/mosdepth"
-  trgt-lps: "/hpf/largeprojects/ccmbio/ccmmarvin_shared/pacbio_longread_pilot_phase_2/tools/TRGT-LPSv0.3.0/trgt-lps-v0.3.0"
+  trgt-lps: "/hpf/largeprojects/ccmbio/ccmmarvin_shared/pacbio_longread_pilot_phase_2/tools/TRGT-LPSv0.4.0/trgt-lps-v0.4.0"
 
 ref:
   name: GRCh38.86

--- a/config.yaml
+++ b/config.yaml
@@ -73,6 +73,7 @@ trgt:
   gnomad_constraint: "/hpf/largeprojects/ccmbio/ccmmarvin_shared/pacbio_longread_pilot_phase_1/TRGT/proband_only_workflow/annotations/gnomad.v4.0.constraint_metrics.tsv"
   segdup: "/hpf/largeprojects/ccmbio/ccmmarvin_shared/pacbio_longread_pilot_phase_1/data/reference/annotation/GRCh38.segdups.bed.gz"
   control_alleles: "/hpf/largeprojects/ccmbio/ccmmarvin_shared/pacbio_longread_pilot_phase_2/code/scripts/trgt/crg2-pacbio/scripts/VCFs/cmh_0.4.0.sorted.no.missing.95perc.vcf.gz"
+  control_alleles_tsv: "/hpf/largeprojects/ccmbio/mcouse/pacbio_report_dev/results/create_cmh_allele_db/repeat_outliers/allele_db/CMH.trgt.v0.5.0.alleles.1436.samples.20240624.tsv"
   C4R_outliers: "/hpf/largeprojects/ccmbio/ccmmarvin_shared/pacbio_longread_pilot_phase_2/results/C4R_all_outliers_batch/outliers/aggregated_outliers_2024-10-09.csv"
   adotto_repeats: "/hpf/largeprojects/ccmbio/ccmmarvin_shared/pacbio_longread_pilot_phase_1/TRGT/repeat_definitions/adotto_repeats.hg38.bed"
   promoters: "/hpf/largeprojects/ccmbio/ccmmarvin_shared/pacbio_longread_pilot_phase_1/TRGT/proband_only_workflow/annotations/GRCh38-PLS.bed"

--- a/config.yaml
+++ b/config.yaml
@@ -21,6 +21,7 @@ tools:
   trgt: "/hpf/largeprojects/ccmbio/ccmmarvin_shared/pacbio_longread_pilot_phase_2/tools/TRGTv1.1.0/trgt-v1.1.0-x86_64-unknown-linux-gnu/trgt"
   trgt-denovo: "/hpf/largeprojects/ccmbio/ccmmarvin_shared/pacbio_longread_pilot_phase_2/tools/trgt-denovo-v0.2.0/trgt-denovo"
   mosdepth: "/hpf/largeprojects/ccmbio/ccmmarvin_shared/pacbio_longread_pilot_phase_2/tools/mosdepth-0.3.11/mosdepth"
+  trgt-lps: "/hpf/largeprojects/ccmbio/ccmmarvin_shared/pacbio_longread_pilot_phase_2/tools/TRGT-LPSv0.3.0/trgt-lps-v0.3.0"
 
 ref:
   name: GRCh38.86

--- a/config.yaml
+++ b/config.yaml
@@ -78,4 +78,4 @@ trgt:
   adotto_repeats: "/hpf/largeprojects/ccmbio/ccmmarvin_shared/pacbio_longread_pilot_phase_1/TRGT/repeat_definitions/adotto_repeats.hg38.bed"
   promoters: "/hpf/largeprojects/ccmbio/ccmmarvin_shared/pacbio_longread_pilot_phase_1/TRGT/proband_only_workflow/annotations/GRCh38-PLS.bed"
   TR_constraint: "/hpf/largeprojects/ccmbio/ccmmarvin_shared/pacbio_longread_pilot_phase_1/TRGT/proband_only_workflow/annotations/Danzi_et_al_2025_supp_table_3.csv"
-  control_lps: "/hpf/largeprojects/ccmbio/ccmmarvin_shared/pacbio_longread_pilot_phase_2/results/CMH_LPS/CMH_combined_LPS.tsv"
+  control_lps: "/hpf/largeprojects/ccmbio/ccmmarvin_shared/pacbio_longread_pilot_phase_2/results/CMH_LPS/CMH_combined_LPS.tsv.gz"

--- a/config.yaml
+++ b/config.yaml
@@ -74,7 +74,7 @@ trgt:
   segdup: "/hpf/largeprojects/ccmbio/ccmmarvin_shared/pacbio_longread_pilot_phase_1/data/reference/annotation/GRCh38.segdups.bed.gz"
   control_alleles: "/hpf/largeprojects/ccmbio/ccmmarvin_shared/pacbio_longread_pilot_phase_2/code/scripts/trgt/crg2-pacbio/scripts/VCFs/cmh_0.4.0.sorted.no.missing.95perc.vcf.gz"
   control_alleles_tsv: "/hpf/largeprojects/ccmbio/mcouse/pacbio_report_dev/results/create_cmh_allele_db/repeat_outliers/allele_db/CMH.trgt.v0.5.0.alleles.1436.samples.20240624.tsv"
-  C4R_outliers: "/hpf/largeprojects/ccmbio/ccmmarvin_shared/pacbio_longread_pilot_phase_2/results/C4R_all_outliers_batch/outliers/aggregated_outliers_2024-10-09.csv"
+  C4R_outliers: "/hpf/largeprojects/ccmbio/ccmmarvin_shared/pacbio_longread_pilot_phase_2/results/C4R_all_outliers_batch/outliers/aggregated_outliers_2025-05-05.csv"
   adotto_repeats: "/hpf/largeprojects/ccmbio/ccmmarvin_shared/pacbio_longread_pilot_phase_1/TRGT/repeat_definitions/adotto_repeats.hg38.bed"
   promoters: "/hpf/largeprojects/ccmbio/ccmmarvin_shared/pacbio_longread_pilot_phase_1/TRGT/proband_only_workflow/annotations/GRCh38-PLS.bed"
   TR_constraint: "/hpf/largeprojects/ccmbio/ccmmarvin_shared/pacbio_longread_pilot_phase_1/TRGT/proband_only_workflow/annotations/Danzi_et_al_2025_supp_table_3.csv"

--- a/config.yaml
+++ b/config.yaml
@@ -78,3 +78,4 @@ trgt:
   adotto_repeats: "/hpf/largeprojects/ccmbio/ccmmarvin_shared/pacbio_longread_pilot_phase_1/TRGT/repeat_definitions/adotto_repeats.hg38.bed"
   promoters: "/hpf/largeprojects/ccmbio/ccmmarvin_shared/pacbio_longread_pilot_phase_1/TRGT/proband_only_workflow/annotations/GRCh38-PLS.bed"
   TR_constraint: "/hpf/largeprojects/ccmbio/ccmmarvin_shared/pacbio_longread_pilot_phase_1/TRGT/proband_only_workflow/annotations/Danzi_et_al_2025_supp_table_3.csv"
+  control_lps: "/hpf/largeprojects/ccmbio/ccmmarvin_shared/pacbio_longread_pilot_phase_2/results/CMH_LPS/CMH_combined_LPS.tsv"

--- a/rules/denovo_TR.smk
+++ b/rules/denovo_TR.smk
@@ -49,9 +49,9 @@ rule trgt_denovo:
         done < {input.ID_map}
 
         # Get BAM paths
-        child_bam=`cat {input.samples} | grep -P "{wildcards.child}\t" | awk '{{print $2}}' | sed 's/.bam/.trgt/'`
-        father_bam=`cat {input.samples} | grep -P "${{father_ID}}\t" | awk '{{print $2}}' | sed 's/.bam/.trgt/'`
-        mother_bam=`cat {input.samples} | grep -P "${{mother_ID}}\t" | awk '{{print $2}}' | sed 's/.bam/.trgt/'`
+        child_bam=`cat {input.samples} | grep -P "{wildcards.child}\t" | awk '{{print $2}}' | sed 's/.bam/.trgt/' | sed 's/.haplotagged//'`
+        father_bam=`cat {input.samples} | grep -P "${{father_ID}}\t" | awk '{{print $2}}' | sed 's/.bam/.trgt/' | sed 's/.haplotagged//'`  
+        mother_bam=`cat {input.samples} | grep -P "${{mother_ID}}\t" | awk '{{print $2}}' | sed 's/.bam/.trgt/' | sed 's/.haplotagged//'`
 	echo         {params.trgt_denovo} trio --reference {params.ref} \
                 --bed {params.bed} \
                 --father $father_bam \
@@ -78,7 +78,7 @@ rule annotate_trgt_denovo:
       constraint = config["trgt"]["gnomad_constraint"],
       OMIM = config["annotation"]["omim_path"],
       segdup = config["trgt"]["segdup"],
-      controls = config["trgt"]["control_alleles"],
+      controls = config["trgt"]["control_alleles_tsv"],
       c4r = config["annotation"]["c4r"],
       HPO = config["run"]["hpo"] if config["run"]["hpo"] else "none",
       c4r_outliers = config["trgt"]["C4R_outliers"]

--- a/rules/outlier_expansions.smk
+++ b/rules/outlier_expansions.smk
@@ -1,21 +1,103 @@
+rule genotype_adotto_loci:
+    input: get_bam
+    output: 
+        vcf = temp("repeat_outliers/{family}_{sample}.trgt.unsorted.vcf.gz"),
+        spanning_bam = "repeat_outliers/{family}_{sample}.trgt.unsorted.spanning.bam"
+    params: 
+        trgt = config["tools"]["trgt"],
+        ref = config["ref"]["genome"],
+        repeats = config["trgt"]["adotto_repeats"]
+    log: "logs/repeat_outliers/{family}_{sample}.trgt.log"
+    conda:
+        "../envs/common.yaml"
+    threads: 10
+    resources:
+        mem_mb = 60000
+    shell: 
+        """
+        # get sex, code from https://github.com/ccmbioinfo/crg/get_XY.sh
+        x=`samtools idxstats {input} | egrep  "X|chrX"`;
+        y=`samtools idxstats {input} | egrep  "Y|chrY"`;
+        xcov=`echo $x | awk '{{ printf("%0.5f", $3/$2); }}'`;
+        ycov=`echo $y | awk '{{ printf("%0.5f", $3/$2); }}'`;
+
+        rat=$(echo "scale=4; ${{xcov}}/${{ycov}}" | bc)
+        if (( $(echo "$rat > 5.0" | bc -l) )); then
+            sex=XX
+        else
+            sex=XY
+        fi
+
+        echo "$sex"
+
+        {params.trgt} genotype --genome {params.ref} \
+            --reads {input} \
+            --repeats {params.repeats} \
+            --output-prefix repeat_outliers/{wildcards.family}_{wildcards.sample}.trgt.unsorted \
+            --karyotype $sex \
+            --sample-name {wildcards.family}_{wildcards.sample} \
+            --threads {threads}
+        """       
+
+# rule sort_trgt_adotto_vcf:
+#     input: "repeat_outliers/{family}_{sample}.trgt.unsorted.vcf.gz"
+#     output: "repeat_outliers/{family}_{sample}.trgt.vcf.gz"
+#     log: "logs/bcftools/{family}_{sample}.sort.trgt.log"
+#     conda:
+#         "../envs/common.yaml"
+#     shell:
+#         """
+#         bcftools sort -Ob -o {output} {input};
+#         bcftools index {output}
+#         """
+
 rule merge_trgt_vcf:
-    input: config["run"]["units"]
+    input: 
+        vcf = expand("repeat_outliers/{{family}}_{sample}.trgt.unsorted.vcf.gz", sample=samples.index),
+        indices = expand("repeat_outliers/{{family}}_{sample}.trgt.unsorted.vcf.gz.tbi", sample=samples.index) 
     params:
         trgt = config["tools"]["trgt"],
         genome = config["ref"]["genome"]
     output: "repeat_outliers/{family}.trgt.vcf.gz"
     log: "logs/repeat_outliers/{family}.merge.trgt.vcf.log"
     shell:
-        """
+        """ 
         export TMPDIR=`pwd`
-        dir=`awk -F "\t" '{{print $4}}' {input} | tail -n 1`
-        vcf=`echo $dir/*vcf.gz`
         {params.trgt} -vv merge \
-            --vcf $vcf \
+            --vcf {input.vcf} \
             --force-single \
             --genome {params.genome} \
             --output-type z > {output}
         """
+
+rule calculate_lps: 
+    input: "repeat_outliers/{family}_{sample}.trgt.unsorted.vcf.gz"
+    output: temp("repeat_outliers/{family}_{sample}.trgt.lps.tsv")
+    params:
+        trgt_lps = config["tools"]["trgt-lps"]
+    log: "logs/repeat_outliers/{family}_{sample}.trgt.lps.log"
+    shell:
+        """
+        {params.trgt_lps} --vcf {input} > {output}
+        """
+
+rule combine_lps: 
+    input: 
+        lps = expand("repeat_outliers/{{family}}_{sample}.trgt.lps.tsv", sample=samples.index)
+    output: "repeat_outliers/{family}.trgt.lps.combined.tsv"
+    log: "logs/repeat_outliers/{family}.trgt.lps.combined.log"
+    run:
+        import pandas as pd
+        files = input.lps
+        lps_list = []
+        for file in files: 
+            print(files)
+            df = pd.read_csv(file, sep="\t")
+            sample = file.split("/")[-1].split(".")[0]
+            df["sample"] = sample
+            lps_list.append(df)
+        lps_df = pd.concat(lps_list)
+        lps_df.to_csv(output[0], sep="\t", index=False)
 
 rule sort_merged_trgt_vcf:
     input: "repeat_outliers/{family}.trgt.vcf.gz"
@@ -32,7 +114,8 @@ rule sort_merged_trgt_vcf:
 rule find_repeat_outliers:
     input: 
         case_vcf = "repeat_outliers/{family}.trgt.sorted.vcf.gz",
-        control_vcf = config["trgt"]["control_alleles"]
+        control_vcf = config["trgt"]["control_alleles"], 
+        lps = "repeat_outliers/{family}.trgt.lps.combined.tsv"
     output: "repeat_outliers/{family}.repeat.outliers.tsv"
     params:
         crg2_pacbio = config["tools"]["crg2_pacbio"]
@@ -45,9 +128,9 @@ rule find_repeat_outliers:
         """
         (python3 {params.crg2_pacbio}/scripts/find_repeat_outliers.py --case_vcf {input.case_vcf} \
             --control_vcf {input.control_vcf} \
+            --case_lps {input.lps} \
             --output_file  {output}) > {log} 2>&1 
         """
-
 
 rule annotate_repeat_outliers:
     input: "repeat_outliers/{family}.repeat.outliers.tsv"

--- a/rules/outlier_expansions.smk
+++ b/rules/outlier_expansions.smk
@@ -84,7 +84,7 @@ rule calculate_lps:
 rule combine_lps: 
     input: 
         lps = expand("repeat_outliers/{{family}}_{sample}.trgt.lps.tsv", sample=samples.index)
-    output: "repeat_outliers/{family}.trgt.lps.combined.tsv"
+    output: "repeat_outliers/{family}.trgt.lps.combined.tsv.gz"
     log: "logs/repeat_outliers/{family}.trgt.lps.combined.log"
     run:
         import pandas as pd
@@ -97,7 +97,7 @@ rule combine_lps:
             df["sample"] = sample
             lps_list.append(df)
         lps_df = pd.concat(lps_list)
-        lps_df.to_csv(output[0], sep="\t", index=False)
+        lps_df.to_csv(output[0], sep="\t", index=False, compression="gzip")
 
 # rule sort_merged_trgt_vcf:
 #     input: "repeat_outliers/{family}.trgt.vcf.gz"
@@ -115,14 +115,14 @@ rule find_repeat_outliers:
     input: 
         case_vcf = "repeat_outliers/{family}.trgt.vcf.gz",
         control_vcf = config["trgt"]["control_alleles"], 
-        lps = "repeat_outliers/{family}.trgt.lps.combined.tsv",
+        lps = "repeat_outliers/{family}.trgt.lps.combined.tsv.gz",
         control_lps = config["trgt"]["control_lps"]
     output: "repeat_outliers/{family}.repeat.outliers.tsv"
     params:
         crg2_pacbio = config["tools"]["crg2_pacbio"]
     log:  "logs/repeat_outliers/{family}.repeat.outliers.log"
     resources:
-        mem_mb = 100000
+        mem_mb = 300000
     conda: 
         "../envs/str_sv.yaml"
     shell: 

--- a/rules/outlier_expansions.smk
+++ b/rules/outlier_expansions.smk
@@ -145,7 +145,8 @@ rule annotate_repeat_outliers:
       c4r_outliers = config["trgt"]["C4R_outliers"],
       c4r = config["annotation"]["c4r"],
       promoters = config["trgt"]["promoters"],
-      TR_constraint = config["trgt"]["TR_constraint"]
+      TR_constraint = config["trgt"]["TR_constraint"],
+      repeat_catalog = config["trgt"]["adotto_repeats"]
     resources:
         mem_mb = 20000
     conda: 
@@ -162,6 +163,7 @@ rule annotate_repeat_outliers:
                 --promoters {params.promoters} \
                 --TR_constraint {params.TR_constraint} \
                 --c4r {params.c4r} \
+                --repeat_catalog {params.repeat_catalog} \
 		        --c4r_outliers {params.c4r_outliers}) > {log} 2>&1
         else
             (python3 {params.crg2_pacbio}/scripts/annotate_repeat_outliers.py --repeats {input} \
@@ -172,6 +174,7 @@ rule annotate_repeat_outliers:
                 --promoters {params.promoters} \
                 --TR_constraint {params.TR_constraint} \
                 --c4r {params.c4r} \
+                --repeat_catalog {params.repeat_catalog} \
                 --hpo {params.HPO} \
                 --c4r_outliers {params.c4r_outliers}) > {log} 2>&1
         fi

--- a/rules/outlier_expansions.smk
+++ b/rules/outlier_expansions.smk
@@ -115,7 +115,8 @@ rule find_repeat_outliers:
     input: 
         case_vcf = "repeat_outliers/{family}.trgt.vcf.gz",
         control_vcf = config["trgt"]["control_alleles"], 
-        lps = "repeat_outliers/{family}.trgt.lps.combined.tsv"
+        lps = "repeat_outliers/{family}.trgt.lps.combined.tsv",
+        control_lps = config["trgt"]["control_lps"]
     output: "repeat_outliers/{family}.repeat.outliers.tsv"
     params:
         crg2_pacbio = config["tools"]["crg2_pacbio"]
@@ -129,6 +130,7 @@ rule find_repeat_outliers:
         (python3 {params.crg2_pacbio}/scripts/find_repeat_outliers.py --case_vcf {input.case_vcf} \
             --control_vcf {input.control_vcf} \
             --case_lps {input.lps} \
+            --control_lps {input.control_lps} \
             --output_file  {output}) > {log} 2>&1 
         """
 

--- a/scripts/annotate_repeat_outliers.py
+++ b/scripts/annotate_repeat_outliers.py
@@ -59,6 +59,8 @@ def main(
 
 
     hits_pivot["min_z_score_len_rank"] = hits_pivot[z_score_len_rank_cols].min(axis=1)
+    LPS_rank_cols = [col for col in hits_pivot.columns if "LPS_rank" in col]
+    hits_pivot["min_LPS_rank"] = hits_pivot[LPS_rank_cols].min(axis=1)
 
     # make a column with maximum LPS across samples
     lps_cols = [col for col in hits_pivot.columns if "LPS" in col and 'rank' not in col and 'z_score' not in col]
@@ -176,7 +178,7 @@ def main(
     am_cols = [col for col in hits_gene_omim.columns if "AM" in col]
     mp_cols = [col for col in hits_gene_omim.columns if "MP" in col]
     z_score_ranks_cols = [col for col in hits_gene_omim.columns if "z_score_len_rank" in col and 'min' not in col]
-    lps_cols = [col for col in hits_gene_omim.columns if "LPS" in col and 'max' not in col]
+    lps_cols = [col for col in hits_gene_omim.columns if "LPS" in col and 'max' not in col and 'min' not in col]
 
     hits_gene_omim = hits_gene_omim[
         ["Chromosome", "Start", "End", "trid", "motif", "gene_name", "gene_id", "gene_biotype", "Feature"]
@@ -184,9 +186,8 @@ def main(
         + ["gene", "lof.oe_ci.upper", "lof.pLI", "OE_len"]
         + ["ENCODE_promoter_ID", "ENCODE_promoter_coord", "range", "cutoff", "allele_len_std"]
         + c4r_col
-        + ["max_sample_allele_len", "max_z_score_len", "min_z_score_len_rank", "max_LPS"]
+        + ["max_sample_allele_len", "max_z_score_len", "min_z_score_len_rank", "num_outlier_samples", "max_LPS", "min_LPS_rank"]
         + lps_cols
-        + ["num_outlier_samples"]
         + al_cols
         + z_score_cols
         + z_score_ranks_cols

--- a/scripts/annotate_repeat_outliers.py
+++ b/scripts/annotate_repeat_outliers.py
@@ -61,7 +61,7 @@ def main(
     hits_pivot["min_z_score_len_rank"] = hits_pivot[z_score_len_rank_cols].min(axis=1)
 
     # make a column with maximum LPS across samples
-    lps_cols = [col for col in hits_pivot.columns if "LPS" in col]
+    lps_cols = [col for col in hits_pivot.columns if "LPS" in col and 'rank' not in col and 'z_score' not in col]
     for col in lps_cols:
         hits_pivot[col] = [
             lps if not pd.isnull(lps) else None

--- a/scripts/annotate_repeat_outliers.py
+++ b/scripts/annotate_repeat_outliers.py
@@ -71,7 +71,7 @@ def main(
     hits_pivot = annotate_motif(hits_pivot, repeat_catalog)
 
     # make a column that sums the number of individuals carrying a particular repeat expansion
-    hits_pivot["num_samples"] = hits_pivot.apply(
+    hits_pivot["num_outlier_samples"] = hits_pivot.apply(
         lambda row: num_expanded(row, al_cols, z_score_cols), axis=1
     )
 
@@ -179,7 +179,7 @@ def main(
         + c4r_col
         + ["max_sample_allele_len", "max_z_score_len", "min_z_score_len_rank", "max_LPS"]
         + lps_cols
-        + ["num_samples"]
+        + ["num_outlier_samples"]
         + al_cols
         + z_score_cols
         + z_score_ranks_cols

--- a/scripts/annotate_repeat_outliers.py
+++ b/scripts/annotate_repeat_outliers.py
@@ -47,6 +47,15 @@ def main(
         ]
     hits_pivot["max_z_score_len"] = hits_pivot[z_score_cols].max(axis=1)
 
+    # make a column with maximum LPS across samples
+    lps_cols = [col for col in hits_pivot.columns if "LPS" in col]
+    for col in lps_cols:
+        hits_pivot[col] = [
+            lps if not pd.isnull(lps) else None
+            for lps in hits_pivot[col]
+        ]
+    hits_pivot["max_LPS"] = hits_pivot[lps_cols].max(axis=1)
+
     # filter out non-outliers
     print("Filter outliers")
     hits_pivot = hits_pivot[hits_pivot["max_z_score_len"].abs() >= 3]
@@ -153,7 +162,7 @@ def main(
     am_cols = [col for col in hits_gene_omim.columns if "AM" in col]
     mp_cols = [col for col in hits_gene_omim.columns if "MP" in col]
     z_score_ranks_cols = [col for col in hits_gene_omim.columns if "z_score_len_rank" in col]
-    lps_cols = [col for col in hits_gene_omim.columns if "LPS" in col]
+    lps_cols = [col for col in hits_gene_omim.columns if "LPS" in col and 'max' not in col]
 
     hits_gene_omim = hits_gene_omim[
         ["Chromosome", "Start", "End", "trid", "motif", "gene_name", "gene_id", "gene_biotype", "Feature"]
@@ -161,6 +170,7 @@ def main(
         + ["gene", "lof.oe_ci.upper", "lof.pLI", "OE_len"]
         + ["ENCODE_promoter_ID", "ENCODE_promoter_coord", "range", "cutoff", "allele_len_std"]
         + c4r_col
+        + ["max_LPS"]
         + lps_cols
         + ["max_z_score_len", "num_samples"]
         + al_cols

--- a/scripts/annotate_repeat_outliers.py
+++ b/scripts/annotate_repeat_outliers.py
@@ -58,6 +58,10 @@ def main(
         ]
     hits_pivot["max_LPS"] = hits_pivot[lps_cols].max(axis=1)
 
+    # make a column with maximum allele length across samples
+    al_cols = [col for col in hits_pivot.columns if "_allele_len" in col]
+    hits_pivot["max_sample_allele_len"] = hits_pivot[al_cols].max(axis=1)
+
     # filter out non-outliers
     print("Filter outliers")
     hits_pivot = hits_pivot[hits_pivot["max_z_score_len"].abs() >= 3]
@@ -67,7 +71,6 @@ def main(
     hits_pivot = annotate_motif(hits_pivot, repeat_catalog)
 
     # make a column that sums the number of individuals carrying a particular repeat expansion
-    al_cols = [col for col in hits_pivot.columns if "_allele_len" in col]
     hits_pivot["num_samples"] = hits_pivot.apply(
         lambda row: num_expanded(row, al_cols, z_score_cols), axis=1
     )
@@ -165,7 +168,7 @@ def main(
 
     am_cols = [col for col in hits_gene_omim.columns if "AM" in col]
     mp_cols = [col for col in hits_gene_omim.columns if "MP" in col]
-    z_score_ranks_cols = [col for col in hits_gene_omim.columns if "z_score_len_rank" in col]
+    z_score_ranks_cols = [col for col in hits_gene_omim.columns if "z_score_len_rank" in col and 'min' not in col]
     lps_cols = [col for col in hits_gene_omim.columns if "LPS" in col and 'max' not in col]
 
     hits_gene_omim = hits_gene_omim[
@@ -174,9 +177,9 @@ def main(
         + ["gene", "lof.oe_ci.upper", "lof.pLI", "OE_len"]
         + ["ENCODE_promoter_ID", "ENCODE_promoter_coord", "range", "cutoff", "allele_len_std"]
         + c4r_col
-        + ["max_LPS"]
+        + ["max_sample_allele_len", "max_z_score_len", "min_z_score_len_rank", "max_LPS"]
         + lps_cols
-        + ["max_z_score_len", "min_z_score_len_rank", "num_samples"]
+        + ["num_samples"]
         + al_cols
         + z_score_cols
         + z_score_ranks_cols

--- a/scripts/annotate_repeat_outliers.py
+++ b/scripts/annotate_repeat_outliers.py
@@ -123,8 +123,8 @@ def main(
     promoters = pr.read_bed(promoters)
     hits_gene_omim_pr = pr.PyRanges(hits_gene_omim)
     hits_gene_omim = hits_gene_omim_pr.join(promoters, how="left", suffix="_promoter").df
-    hits_gene_omim["ENCODE_promoter_coord"] = hits_gene_omim["Chromosome"].astype(str) + ":" + hits_gene_omim["Start_promoter"].astype(str) + "-" + hits_gene_omim["End_promoter"].astype(str)
-    hits_gene_omim.loc[hits_gene_omim["Score"] == -1, "ENCODE_promoter_coord"] = "."
+    hits_gene_omim.loc[hits_gene_omim["Score"] == "-1", "ENCODE_promoter_coord"] = "."
+    hits_gene_omim.loc[hits_gene_omim["Score"] != "-1", "ENCODE_promoter_coord"] = hits_gene_omim["Chromosome"].astype(str) + ":" + hits_gene_omim["Start_promoter"].astype(str) + "-" + hits_gene_omim["End_promoter"].astype(str)
     hits_gene_omim.rename(columns={"Score": "ENCODE_promoter_ID"}, inplace=True)
     hits_gene_omim = hits_gene_omim.drop(columns=["Start_promoter", "End_promoter", "Name", "Strand"])
 

--- a/scripts/annotate_repeat_outliers.py
+++ b/scripts/annotate_repeat_outliers.py
@@ -149,14 +149,15 @@ def main(
     am_cols = [col for col in hits_gene_omim.columns if "AM" in col]
     mp_cols = [col for col in hits_gene_omim.columns if "MP" in col]
     z_score_ranks_cols = [col for col in hits_gene_omim.columns if "z_score_len_rank" in col]
-    
-    
+    lps_cols = [col for col in hits_gene_omim.columns if "LPS" in col]
+
     hits_gene_omim = hits_gene_omim[
         ["Chromosome", "Start", "End", "trid", "motif", "gene_name", "gene_id", "gene_biotype", "Feature"]
         + ["omim_phenotype","omim_inheritance", "HPO"]
         + ["gene", "lof.oe_ci.upper", "lof.pLI", "OE_len"]
         + ["ENCODE_promoter_ID", "ENCODE_promoter_coord", "range", "cutoff"]
         + c4r_col
+        + lps_cols
         + ["max_z_score_len", "num_samples"]
         + al_cols
         + z_score_cols

--- a/scripts/annotate_repeat_outliers.py
+++ b/scripts/annotate_repeat_outliers.py
@@ -159,14 +159,13 @@ def main(
         ["Chromosome", "Start", "End", "trid", "motif", "gene_name", "gene_id", "gene_biotype", "Feature"]
         + ["omim_phenotype","omim_inheritance", "HPO"]
         + ["gene", "lof.oe_ci.upper", "lof.pLI", "OE_len"]
-        + ["ENCODE_promoter_ID", "ENCODE_promoter_coord", "range", "cutoff"]
+        + ["ENCODE_promoter_ID", "ENCODE_promoter_coord", "range", "cutoff", "allele_len_std"]
         + c4r_col
         + lps_cols
         + ["max_z_score_len", "num_samples"]
         + al_cols
         + z_score_cols
         + z_score_ranks_cols
-        + ["allele_len_std"]
         + am_cols
         + mp_cols
     ]

--- a/scripts/annotate_repeat_outliers.py
+++ b/scripts/annotate_repeat_outliers.py
@@ -193,9 +193,11 @@ def main(
             "Start": "POS",
             "End": "END",
             "trid": "TRID",
-            "gene": "gnomad_constraint_gene",
+            "gene": "gnomad_constraint_gene", 
             "allele_len_std": "CMH_allele_len_std",
-            "range": "control_range"
+            "range": "CMH_allele_len_range",
+            "cutoff": "CMH_outlier_cutoff",
+            "OE_len": "TR_constraint"
         }
     )
 

--- a/scripts/annotate_repeat_outliers.py
+++ b/scripts/annotate_repeat_outliers.py
@@ -194,7 +194,8 @@ def main(
             "End": "END",
             "trid": "TRID",
             "gene": "gnomad_constraint_gene",
-            "allele_len_std": "CMH_allele_len_std"
+            "allele_len_std": "CMH_allele_len_std",
+            "range": "control_range"
         }
     )
 

--- a/scripts/annotate_repeat_outliers.py
+++ b/scripts/annotate_repeat_outliers.py
@@ -107,6 +107,7 @@ def main(
      
     try: 
         c4r_counts = pd.read_csv(c4r_counts)
+        c4r_counts["TRID"] = c4r_counts["TRID"].str.rsplit("_", n=3).str[0] + "_" + c4r_counts["TRID"].str.split("_").str[4]
         hits_gene_omim = hits_gene_omim.merge(c4r_counts, left_on="trid", right_on="TRID", how="left")
         hits_gene_omim["count"] = hits_gene_omim["count"].replace(np.nan, 0)
         hits_gene_omim = hits_gene_omim.rename({"count": "C4R_outlier_count", "samples": "C4R_outlier_samples"}, axis=1)

--- a/scripts/annotate_repeat_outliers.py
+++ b/scripts/annotate_repeat_outliers.py
@@ -204,6 +204,10 @@ def main(
 
     # drop dups
     hits_gene_omim = hits_gene_omim.drop_duplicates()
+
+    # sort by max_LPS
+    hits_gene_omim = hits_gene_omim.sort_values(by="max_LPS", ascending=False)
+    
     # write to file
     today = date.today()
     today = today.strftime("%Y-%m-%d")

--- a/scripts/annotate_repeat_outliers.py
+++ b/scripts/annotate_repeat_outliers.py
@@ -67,7 +67,7 @@ def main(
     # make a column that sums the number of individuals carrying a particular repeat expansion
     al_cols = [col for col in hits_pivot.columns if "_allele_len" in col]
     hits_pivot["num_samples"] = hits_pivot.apply(
-        lambda row: num_expanded(row, al_cols), axis=1
+        lambda row: num_expanded(row, al_cols, z_score_cols), axis=1
     )
 
     # convert hits to PyRanges object
@@ -124,6 +124,7 @@ def main(
     hits_gene_omim_pr = pr.PyRanges(hits_gene_omim)
     hits_gene_omim = hits_gene_omim_pr.join(promoters, how="left", suffix="_promoter").df
     hits_gene_omim["ENCODE_promoter_coord"] = hits_gene_omim["Chromosome"].astype(str) + ":" + hits_gene_omim["Start_promoter"].astype(str) + "-" + hits_gene_omim["End_promoter"].astype(str)
+    hits_gene_omim.loc[hits_gene_omim["Score"] == -1, "ENCODE_promoter_coord"] = "."
     hits_gene_omim.rename(columns={"Score": "ENCODE_promoter_ID"}, inplace=True)
     hits_gene_omim = hits_gene_omim.drop(columns=["Start_promoter", "End_promoter", "Name", "Strand"])
 
@@ -198,7 +199,7 @@ def main(
     except KeyError:
         pass 
     hits_gene_omim.fillna(".", inplace=True)
-    hits_gene_omim.replace({"-1": ".", "1:-1--1": "."}, inplace=True)
+    hits_gene_omim.replace({"-1": ".", "1:-1--1": ".", " ": ".", "nan": "."}, inplace=True)
 
     # drop dups
     hits_gene_omim = hits_gene_omim.drop_duplicates()

--- a/scripts/annotate_repeat_outliers.py
+++ b/scripts/annotate_repeat_outliers.py
@@ -9,6 +9,7 @@ from typing import Optional
 from annotation.annotate import (
     pivot_hits,
     hits_to_pr,
+    annotate_motif,
     annotate_genes,
     gene_set,
     num_expanded,
@@ -29,6 +30,7 @@ def main(
     promoters: str,
     TR_constraint: str,
     c4r: bool,
+    repeat_catalog: str,
     hpo: Optional[str] = None,
     c4r_counts: Optional[str] = None
 ) -> None:
@@ -48,6 +50,10 @@ def main(
     # filter out non-outliers
     print("Filter outliers")
     hits_pivot = hits_pivot[hits_pivot["max_z_score_len"].abs() >= 3]
+
+    # annotate with motif
+    print("Annotate with motif")
+    hits_pivot = annotate_motif(hits_pivot, repeat_catalog)
 
     # make a column that sums the number of individuals carrying a particular repeat expansion
     al_cols = [col for col in hits_pivot.columns if "_allele_len" in col]
@@ -103,8 +109,6 @@ def main(
     if c4r != "True": 
         c4r_col = ["C4R_outlier_count"] # remove C4R sample IDs for non-C4R projects
 
-    # add motif
-    hits_gene_omim["motif"] = hits_gene_omim["TRID"].str.split("_").str[3]
 
     # add promoters
     promoters = pr.read_bed(promoters)
@@ -250,6 +254,11 @@ if __name__ == "__main__":
         help="True if C4R project, otherwise false (C4R outlier sample IDs will be excluded from report)",
     )
     parser.add_argument(
+        "--repeat_catalog",
+        type=str,
+        help="Path to TRGT repeat catalog",
+    )
+    parser.add_argument(
         "--hpo",
         type=str,
         help="Path to HPO terms file",
@@ -271,6 +280,7 @@ if __name__ == "__main__":
         args.promoters,
         args.TR_constraint,
         args.c4r,
+        args.repeat_catalog,
         args.hpo,
         args.c4r_outliers
     )

--- a/scripts/annotate_repeat_outliers.py
+++ b/scripts/annotate_repeat_outliers.py
@@ -112,14 +112,14 @@ def main(
         c4r_counts["TRID"] = c4r_counts["TRID"].str.rsplit("_", n=3).str[0] + "_" + c4r_counts["TRID"].str.split("_").str[4]
         hits_gene_omim = hits_gene_omim.merge(c4r_counts, left_on="trid", right_on="TRID", how="left")
         hits_gene_omim["count"] = hits_gene_omim["count"].replace(np.nan, 0)
-        hits_gene_omim = hits_gene_omim.rename({"count": "C4R_outlier_count", "samples": "C4R_outlier_samples"}, axis=1)
-        c4r_col = ["C4R_outlier_count", "C4R_outlier_samples"]
+        hits_gene_omim = hits_gene_omim.rename({"count": "C4R_outlier_count", "samples": "C4R_outlier_samples", "allele_lens": "C4R_outlier_allele_lens"}, axis=1)
+        c4r_col = ["C4R_outlier_count", "C4R_outlier_samples", "C4R_outlier_allele_lens"]
     except:
         print("Failed to add C4R counts") 
         c4r_col = []
     
     if c4r != "True": 
-        c4r_col = ["C4R_outlier_count"] # remove C4R sample IDs for non-C4R projects
+        c4r_col = ["C4R_outlier_count", "C4R_outlier_allele_lens"] # remove C4R sample IDs for non-C4R projects
 
 
     # add promoters

--- a/scripts/annotation/annotate.py
+++ b/scripts/annotation/annotate.py
@@ -15,7 +15,7 @@ def pivot_hits(df: pd.DataFrame) -> pd.DataFrame:
     hit_pivot = hits.pivot(
         index=["trid", "range", "cutoff", "allele_len_std"],
         columns="sample",
-        values=["allele_len", "z_score_len", "z_score_len_rank", "allele_len_std", "AM", "z_score_AM", "MP", "z_score_MP"],
+        values=["allele_len", "z_score_len", "z_score_len_rank", "allele_len_std", "AM", "z_score_AM", "MP", "z_score_MP", "LPS"],
     ).reset_index()
 
     hit_pivot.columns = (
@@ -34,6 +34,7 @@ def pivot_hits(df: pd.DataFrame) -> pd.DataFrame:
             "_z_score_MP": "z_score_MP",
             "_z_score_len_rank": "z_score_len_rank",
             "_allele_len_std": "allele_len_std",
+            "_LPS": "LPS",
         }
     )
 

--- a/scripts/annotation/annotate.py
+++ b/scripts/annotation/annotate.py
@@ -352,13 +352,14 @@ def filter_outliers(row: pd.Series, allele_len_cols: list) -> bool:
         return True # missing in control database
 
 
-def num_expanded(row: pd.Series, allele_len_cols: list) -> bool:
+def num_expanded(row: pd.Series, allele_len_cols: list, z_score_cols: list) -> bool:
     """
-    Sum number of individuals in whom repeat is expanded (i.e. allele length > cutoff)
+    Sum number of individuals in whom repeat is expanded (i.e. allele length > cutoff AND Z-score > 3)
     """
     allele_lens = [row[allele_len] for allele_len in allele_len_cols]
+    z_scores = [row[z_score] for z_score in z_score_cols]
     cutoff = row["cutoff"] if not pd.isna(row["cutoff"]) else 0
-    greater_than = sum([allele_len >= cutoff for allele_len in allele_lens])
+    greater_than = sum([allele_len >= cutoff and z_score >= 3 for allele_len, z_score in zip(allele_lens, z_scores)])
 
     return greater_than
 

--- a/scripts/annotation/annotate.py
+++ b/scripts/annotation/annotate.py
@@ -15,7 +15,7 @@ def pivot_hits(df: pd.DataFrame) -> pd.DataFrame:
     hit_pivot = hits.pivot(
         index=["trid", "range", "cutoff", "allele_len_std"],
         columns="sample",
-        values=["allele_len", "z_score_len", "z_score_len_rank", "allele_len_std", "AM", "z_score_AM", "MP", "z_score_MP", "LPS"],
+        values=["allele_len", "z_score_len", "z_score_len_rank", "AM", "z_score_AM", "MP", "z_score_MP", "LPS"],
     ).reset_index()
 
     hit_pivot.columns = (
@@ -28,12 +28,12 @@ def pivot_hits(df: pd.DataFrame) -> pd.DataFrame:
             "_trid": "trid",
             "_range": "range",
             "_cutoff": "cutoff",
+            "_allele_len_std": "allele_len_std",
             "_AM": "AM",
             "_z_score_AM": "z_score_AM",
             "_MP": "MP",
             "_z_score_MP": "z_score_MP",
             "_z_score_len_rank": "z_score_len_rank",
-            "_allele_len_std": "allele_len_std",
             "_LPS": "LPS",
         }
     )

--- a/scripts/annotation/annotate.py
+++ b/scripts/annotation/annotate.py
@@ -15,7 +15,7 @@ def pivot_hits(df: pd.DataFrame) -> pd.DataFrame:
     hit_pivot = hits.pivot(
         index=["trid", "range", "cutoff", "allele_len_std"],
         columns="sample",
-        values=["allele_len", "z_score_len", "z_score_len_rank", "AM", "z_score_AM", "MP", "z_score_MP", "LPS"],
+        values=["allele_len", "z_score_len", "z_score_len_rank", "AM", "z_score_AM", "MP", "z_score_MP", "LPS", "z_score_LPS", "LPS_rank"],
     ).reset_index()
 
     hit_pivot.columns = (
@@ -35,6 +35,8 @@ def pivot_hits(df: pd.DataFrame) -> pd.DataFrame:
             "_z_score_MP": "z_score_MP",
             "_z_score_len_rank": "z_score_len_rank",
             "_LPS": "LPS",
+            "_z_score_LPS": "z_score_LPS",
+            "_z_score_LPS_rank": "LPS_rank"
         }
     )
 

--- a/scripts/annotation/annotate.py
+++ b/scripts/annotation/annotate.py
@@ -51,6 +51,19 @@ def hits_to_pr(hits: pd.DataFrame) -> pr.PyRanges:
 
     return hit_pr
 
+def annotate_motif(hits: pd.DataFrame, repeat_catalog: str) -> pd.DataFrame:
+    """
+    Annotate TRID motif. These are stripped from the TRID in the outlier file to save space, especially for large families.
+    """
+    repeat_catalog = pd.read_csv(repeat_catalog, sep="\t", header=None, names=["chr", "pos", "end", "ID"])
+    repeat_catalog["trid_short"] = repeat_catalog["ID"].str.split(";").str[0].str.replace("ID=", "").str.rsplit("_",n=1).str[0]
+    repeat_catalog["motif"] = repeat_catalog["ID"].str.split(";").str[1].str.replace("MOTIFS=", "")
+    repeat_catalog = repeat_catalog[["trid_short", "motif"]]
+    hits["trid_short"] = hits["trid"].str.rsplit("_", n=1).str[0]
+    hits = hits.merge(repeat_catalog, on="trid_short", how="left").drop("trid_short", axis=1)
+
+    return hits
+
 def prepare_Ensembl_GTF(gtf_path: str, cols: list) -> pd.DataFrame:
     """
     Convert GTF file into a PyRanges object and clean up columns

--- a/scripts/find_repeat_outliers.py
+++ b/scripts/find_repeat_outliers.py
@@ -218,9 +218,9 @@ def main(case_vcf, case_lps, control_vcf, control_lps, output_file):
             "z_score_MP": [],
             "LPS": [],
             "LPS_mean": [],
-            "LPS_std": [],
-            "z_score_LPS": [],  
-            "z_score_LPS_rank": []
+            "LPS_std": [], 
+            "z_score_LPS": [],
+            "LPS_rank": []
         }
 
         for variant in  vcf_in:
@@ -319,10 +319,10 @@ def main(case_vcf, case_lps, control_vcf, control_lps, output_file):
                     sample_stat_dict["z_score_LPS"].append(zscore_LPS)
                     try:
                         control_LPS.append(LPS)
-                        z_score_LPS_rank = get_rank(control_LPS, LPS)
+                        LPS_rank = get_rank(control_LPS, LPS)
                     except: # no control z-scores available
-                        z_score_LPS_rank = np.nan
-                    sample_stat_dict["z_score_LPS_rank"].append(z_score_LPS_rank)
+                        LPS_rank = np.nan
+                    sample_stat_dict["LPS_rank"].append(LPS_rank)
 
         sample_stat_df = pd.DataFrame.from_dict(sample_stat_dict).round(2)
         sample_stat_df.to_csv(output_file, sep="\t", index=False)

--- a/slurm_profile/slurm-config.yaml
+++ b/slurm_profile/slurm-config.yaml
@@ -32,3 +32,6 @@ vcf2db:
 methbat_build_cohort:
   mem: "600G"
 
+find_repeat_outliers:
+  mem: "100G"
+  time: "60:00:00"


### PR DESCRIPTION
Summary of pipeline changes: 
- Previously, used TCAG TRGT (v0.50) VCF; now run TRGT (v1.1.0) within pipeline. This allows us to customize TRGT version, and easily rename sample field to use crg2-pacbio style IDs. Note to self:  it may be a good idea to regenerate the C4R outlier reports for the C4R outlier count column using this TRGT version.
- Calculate LPS (longest pure segment) per allele per family member using TRGT-LPS and incorporate into annotations/report.

Annotations added: 
- Promoter regions from ENCODE 
- TR constraint (Supplementary table 3 from 'Detailed tandem repeat allele profiling in 1,027 long-read genomes reveals genome-wide patterns
of pathogenicity')
- Population allele length SD from CMH 
- Minimum LPS length rank relative to CMH
- Maximum LPS (across family members)
- C4R outlier allele lengths
- Maximum sample allele length
- Minimum Z score length rank relative to CMH
- Motif (separated out from TRID column)

Filtering changes:
- Regenerated C4R outlier count to filter by Z score (>=3) in addition to allele length cutoff*
- Outliers in reports are also filtered by both Z score and allele length cutoff
- Modified num_samples (now named num_outlier_samples) to account for both cutoff and Z score 