### PR TITLE
Misc cleanup 

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -30,7 +30,7 @@ rule all:
         "reports/{family}.wgs.coding.CH.csv".format(family=project),
         "reports/{family}.sv.CH.csv".format(family=project),
         "reports/{family}.cnv.CH.csv".format(family=project),
-        "reports/{family}.compound.het.status.csv".format(family=project),
+        "reports/{family}.compound.het.status.CH.csv".format(family=project),
         "reports/{family}.panel.CH.csv".format(family=project),
         "reports/{family}.panel-flank.CH.csv".format(family=project),
         "reports/{family}.wgs.high.impact.CH.csv".format(family=project),

--- a/Snakefile
+++ b/Snakefile
@@ -12,6 +12,7 @@ def get_children_ids(ped_file):
     import pandas as pd
     pedigree = pd.read_csv(ped_file, sep=" ", header=None, 
                           names=["family_ID", "individual_ID", "paternal_ID", "maternal_ID", "sex", "phenotype"])
+    pedigree = pedigree.astype(str)
     children = pedigree[pedigree["paternal_ID"] != "0"][pedigree["maternal_ID"] != "0"]["individual_ID"].apply(lambda x: x.split("_")[1]).values
     family = pedigree["family_ID"].iloc[0]
 
@@ -37,5 +38,5 @@ rule all:
         "reports/{family}.known.path.str.loci.csv".format(family=project),
         expand("reports/{family}_{child}.TRGT.denovo.annotated.csv",
                family=project,
-               child=children) if config["run"]["ped"] else []
+               child=children) if len(children) > 0 else []
 

--- a/config.yaml
+++ b/config.yaml
@@ -56,9 +56,9 @@ annotation:
     ensembl: "/hpf/largeprojects/ccm_dccforge/dccdipg/Common/annotation_hg38/genes/ensembl/Homo_sapiens.GRCh38.109.chr.processed.csv"
     gnomad_constraint: "/hpf/largeprojects/ccm_dccforge/dccdipg/Common/annotation_hg38/gnomAD/v4.1/constraint/gnomad.v4.1.constraint_metrics.tsv"
   sv_report:
-    inhouse_c4r: "/hpf/largeprojects/ccm_dccforge/dccdipg/Common/annotation_hg38/C4R_LRWGS_db/pbsv.allsamples.counts.2025-12-04.bed"
+    inhouse_c4r: "/hpf/largeprojects/ccm_dccforge/dccdipg/Common/annotation_hg38/C4R_LRWGS_db/pbsv.allsamples.counts.2026-02-02.bed"
     cnv_inhouse_c4r: "/hpf/largeprojects/ccm_dccforge/dccdipg/Common/annotation_hg38/C4R_LRWGS_db/hificnv.allsamples.counts.2025-12-18.bed"
-    inhouse_tg: "/hpf/largeprojects/ccm_dccforge/dccdipg/Common/annotation_hg38/TG_LRWGS_db/pbsv.allsamples.counts.2025-12-04.bed"
+    inhouse_tg: "/hpf/largeprojects/ccm_dccforge/dccdipg/Common/annotation_hg38/TG_LRWGS_db/pbsv.allsamples.counts.2026-02-02.bed"
     cnv_inhouse_tg: "/hpf/largeprojects/ccm_dccforge/dccdipg/Common/annotation_hg38/TG_LRWGS_db/hificnv.allsamples.counts.2025-12-17.bed"
     gnomad_SV: "/hpf/largeprojects/ccm_dccforge/dccdipg/Common/annotation_hg38/gnomAD/v4.1/SV/gnomad.v4.1.sv.sites.processed.bed"
     dgv: "/hpf/largeprojects/ccm_dccforge/dccdipg/Common/annotation_hg38/DGV/DGV.GS.hg38.tsv"

--- a/rules/compound_hets.smk
+++ b/rules/compound_hets.smk
@@ -65,6 +65,7 @@ rule identify_compound_hets:
         --ensembl {input.ensembl}  \
         --ensembl_to_NCBI_df {input.ensembl_to_NCBI_df}  \
         --pedigree {input.pedigree}  \
+        --hpo {input.HPO}  \
         --sequence_variant_report_dir {input.small_variant_report_dir}  \
         --panel_variant_report_dir {input.panel_variant_report_dir}  \
         --panel_flank_variant_report_dir {input.panel_flank_variant_report_dir}  \

--- a/rules/compound_hets.smk
+++ b/rules/compound_hets.smk
@@ -49,7 +49,7 @@ rule identify_compound_hets:
         wgs_high_impact_variant_report_CH="reports/{family}.wgs.high.impact.CH.csv",
         SV_report_CH="reports/{family}.sv.CH.csv",
         CNV_report_CH="reports/{family}.cnv.CH.csv",
-        compound_het_status="reports/{family}.compound.het.status.csv",
+        compound_het_status="reports/{family}.compound.het.status.CH.csv",
     params:
         crg2_pacbio = config["tools"]["crg2_pacbio"]
     conda:

--- a/rules/outlier_expansions.smk
+++ b/rules/outlier_expansions.smk
@@ -118,7 +118,7 @@ rule find_repeat_outliers:
         control_vcf = config["trgt"]["control_alleles"], 
         lps = "repeat_outliers/{family}.trgt.lps.combined.tsv.gz",
         control_lps = config["trgt"]["control_lps"]
-    output: "reports/{family}.repeat.outliers.tsv"
+    output: "repeat_outliers/{family}.repeat.outliers.tsv"
     params:
         crg2_pacbio = config["tools"]["crg2_pacbio"]
     log:  "logs/repeat_outliers/{family}.repeat.outliers.log"
@@ -137,7 +137,7 @@ rule find_repeat_outliers:
 
 rule annotate_repeat_outliers:
     input: "repeat_outliers/{family}.repeat.outliers.tsv"
-    output: "repeat_outliers/{family}.repeat.outliers.annotated.csv"
+    output: "reports/{family}.repeat.outliers.annotated.csv"
     log:  "logs/repeat_outliers/{family}.annotate.repeat.outliers.log"
     params: 
       crg2_pacbio = config["tools"]["crg2_pacbio"],

--- a/scripts/annotate_SVs.py
+++ b/scripts/annotate_SVs.py
@@ -312,7 +312,7 @@ def annotate_pop_svs(annotsv_df, pop_svs, cols, variant_type):
             # only keep matches where the size fraction is greater than 0.8, e.g.  an insertion of 1000bp will not be matched to a 100bp insertion at the same position
             window_INS_BND["SVLEN"] = window_INS_BND["SVLEN"].abs()
             window_INS_BND["size_fraction"] = window_INS_BND.apply(lambda x: (min([x["SVLEN"], x["SVLEN_pop"]]))/(max([x["SVLEN"], x["SVLEN_pop"]])), axis=1)
-            window_INS_BND = window_INS_BND[window_INS_BND["size_fraction"] >= 0.8]
+            window_INS_BND = window_INS_BND[(window_INS_BND["size_fraction"] >= 0.8) | (window_INS_BND["SVTYPE"] == "BND")]
             window_INS_BND = window_INS_BND.drop(columns=["size_fraction"])
 
             # now concatenate the window and SVLEN-based matches

--- a/scripts/annotate_compound_hets.py
+++ b/scripts/annotate_compound_hets.py
@@ -391,8 +391,8 @@ def process_structural_variants(
         ]
     logger.info(
         "Retained %d heterozygous %s for proband %s",
-        variant_type,
         len(SV_rare_high_impact),
+        variant_type,
         proband_id,
     )
 

--- a/scripts/annotate_compound_hets.py
+++ b/scripts/annotate_compound_hets.py
@@ -877,10 +877,7 @@ def main():
         }
     )
     
-    wide_variants.to_csv(f"reports/{family}.compound.het.status.csv", index=False)
-    logger.info(
-        "Wrote combined variant annotations to %s.compound.het.status.csv", family
-    )
+    write_report(wide_variants, family, "compound.het.status", logger)
     
     # Annotate reports
     annotate_reports(

--- a/scripts/annotate_compound_hets.py
+++ b/scripts/annotate_compound_hets.py
@@ -4,6 +4,7 @@ from functools import reduce
 import glob
 import logging
 import os
+from os.path import basename, splitext
 import pandas as pd
 import pyranges as pr
 import numpy as np
@@ -91,6 +92,9 @@ def parse_arguments() -> argparse.Namespace:
     )
     parser.add_argument(
         "--pedigree", type=str, required=True, help="Path to pedigree file"
+    )
+    parser.add_argument(
+        "--hpo", type=str, required=True, help="Path to HPO terms file from Phenotips 'Suggested Genes'"
     )
     parser.add_argument(
         "--sample_order", type=str, required=True, help="Path to VCF sample order file"
@@ -632,6 +636,7 @@ def annotate_reports(
     cnv_path: str,
     family: str,
     ensembl_to_NCBI_df: pd.DataFrame,
+    hpo: str,
     logger: logging.Logger,
 ) -> None:
     """Annotate variant reports with compound het status."""
@@ -655,6 +660,7 @@ def annotate_reports(
     # Annotate sequence variant report
     sequence_variant_report_path = glob.glob(f"{sequence_variant_report_dir}/*.wgs.coding.*.csv")[0]
     sequence_variant_report = pd.read_csv(sequence_variant_report_path)
+    sequence_variant_report = compound_hets.add_hpo_terms_to_report(sequence_variant_report, hpo)
     sequence_variant_report = sequence_variant_report.merge(
         gene_CH_status, on="Ensembl_gene_id", how="left"
     )
@@ -664,6 +670,7 @@ def annotate_reports(
     # Annotate panel sequence variant report
     panel_variant_report_path = glob.glob(f"{panel_variant_report_dir}/*.wgs*csv")[0]
     panel_variant_report = pd.read_csv(panel_variant_report_path)
+    panel_variant_report = compound_hets.add_hpo_terms_to_report(panel_variant_report, hpo)
     panel_variant_report = panel_variant_report.merge(
         gene_CH_status, on="Ensembl_gene_id", how="left"
     )
@@ -673,6 +680,7 @@ def annotate_reports(
     # Annotate panel-flank sequence variant report
     panel_flank_variant_report_path = glob.glob(f"{panel_flank_variant_report_dir}/*.wgs*csv")[0]
     panel_flank_variant_report = pd.read_csv(panel_flank_variant_report_path)
+    panel_flank_variant_report = compound_hets.add_hpo_terms_to_report(panel_flank_variant_report, hpo)
     panel_flank_variant_report = panel_flank_variant_report.merge(
         gene_CH_status, on="Ensembl_gene_id", how="left"
     )
@@ -682,6 +690,7 @@ def annotate_reports(
     # Annotate wgs high-impact sequence variant report
     wgs_high_impact_variant_report_path = glob.glob(f"{wgs_high_impact_variant_report_dir}/*.wgs.high.impact*csv")[0]
     wgs_high_impact_variant_report = pd.read_csv(wgs_high_impact_variant_report_path)
+    wgs_high_impact_variant_report = compound_hets.add_hpo_terms_to_report(wgs_high_impact_variant_report, hpo)
     wgs_high_impact_variant_report = wgs_high_impact_variant_report.merge(
         gene_CH_status, on="Ensembl_gene_id", how="left"
     )
@@ -884,6 +893,7 @@ def main():
         args.cnv,
         family,
         ensembl_to_NCBI_df,
+        args.hpo,
         logger,
     )
     

--- a/scripts/compound_hets/compound_hets.py
+++ b/scripts/compound_hets/compound_hets.py
@@ -553,3 +553,20 @@ def replace_NCBI_IDs_with_Ensembl_IDs(variant_df, ensembl_df, ensembl_to_NCBI_df
         gene = row["Gene"]
         if gene in ID_dict and pd.notnull(ID_dict[gene]):
             variant_df.at[idx, "Ensembl_gene_id"] = ID_dict[gene] 
+
+def add_hpo_terms_to_report(report: pd.DataFrame, hpo_terms: str) -> pd.DataFrame:
+    """
+    Add HPO terms to a sequence variant report dataframe.
+
+    Args:
+        report (pd.DataFrame): The sequence varinat report dataframe to add HPO terms to.
+        hpo_terms (str): The path to the HPO terms file from Phenotips 'Suggested Genes'.
+    """
+    hpo_df = pd.read_csv(hpo_terms, comment='#', skip_blank_lines=True, sep="\t",  encoding="ISO-8859-1", engine='python').drop(columns=["HPO IDs"])
+    # Phenotips TSV has a space in column name: " Gene symbol"
+    hpo_df.columns = hpo_df.columns.str.strip()
+    hpo_df = hpo_df.rename(columns={'Gene symbol': 'Gene Symbol'})
+    hpo_df = hpo_df.set_index("Gene ID").drop(columns=["Gene Symbol"])
+    report = report.join(hpo_df, on="Ensembl_gene_id").rename(columns={"Number of occurrences": "HPO_count", "Features": "HPO_terms"})
+    
+    return report


### PR DESCRIPTION
This PR accomplishes the following: 
- ensures TRGT-denovo is not run for non-trios even if pedigree is present in config
- revises report output paths so that they are all written to the `reports` directory
- adds proband HPO terms to sequence variant reports during compound het annotation
- updates the C4R and TG SV databases to include BNDs
- fixes a logging bug in `scripts/annotate_compound_hets.py`
