### PR TITLE
Adapt compound heterozygous module for use with DRAGEN short-read WGS

### DIFF
--- a/rules/compound_hets.smk
+++ b/rules/compound_hets.smk
@@ -5,7 +5,8 @@ rule get_sequence_variants_for_CH:
         variants="small_variants/{family}.{severity}.impact.variants.tsv",
     params:
         severity="{severity}",
-        crg2_pacbio = config["tools"]["crg2_pacbio"]
+        crg2_pacbio = config["tools"]["crg2_pacbio"],
+        seq_type="long"
     log:
         "logs/compound_hets/{family}.get.sequence.variants.for.CH.{severity}.log",
     conda:
@@ -13,7 +14,7 @@ rule get_sequence_variants_for_CH:
     wildcard_constraints:
         severity="HIGH-MED|LOW"
     shell:
-        "{params.crg2_pacbio}/scripts/compound_hets/get_sequence_var_for_CH.sh {input.gemini_db} {params.severity} > {output.variants}"
+        "{params.crg2_pacbio}/scripts/compound_hets/get_sequence_var_for_CH.sh {input.gemini_db} {params.severity} {params.seq_type} > {output.variants}"
 
 rule get_VCF_sample_order:
     input:
@@ -51,14 +52,15 @@ rule identify_compound_hets:
         CNV_report_CH="reports/{family}.cnv.CH.csv",
         compound_het_status="reports/{family}.compound.het.status.CH.csv",
     params:
-        crg2_pacbio = config["tools"]["crg2_pacbio"]
+        crg2_pacbio = config["tools"]["crg2_pacbio"],
+        seq_type="long"
     conda:
         "../envs/str_sv.yaml"
     log:
         "logs/compound_hets/{family}.identify.compound.hets.log",
     shell:
         """
-        (python3 {params.crg2_pacbio}/scripts/annotate_compound_hets.py --high_med {input.high_med_variants} \
+        (python3 {params.crg2_pacbio}/scripts/annotate_compound_hets.py --seq_type {params.seq_type} --high_med {input.high_med_variants} \
         --low {input.low_variants} \
         --sv {input.SV_report}  \
         --cnv {input.CNV_report}  \

--- a/scripts/annotate_compound_hets.py
+++ b/scripts/annotate_compound_hets.py
@@ -200,14 +200,15 @@ def map_zygosity_from_gt_type(gt_type: int) -> str:
     else:
         return ZYGOSITY_MISSING
 
-def write_report(df: pd.DataFrame, family: str, report_type: str, logger: logging.Logger) -> None:
+def write_report(df: pd.DataFrame, family: str, report_type: str, seq_type: str, logger: logging.Logger) -> None:
     """Write report to file."""
     today = date.today()
     today = today.strftime("%Y-%m-%d")
-    df.to_csv(f"reports/{family}.{report_type}.CH.{today}.csv", index=False)
+    suffix = "csv" if seq_type == "long" else "hg38.csv"
+    df.to_csv(f"reports/{family}.{report_type}.CH.{today}.{suffix}", index=False)
     # Write a symlink instead of a new copy for the Snakemake target
-    symlink_path = f"reports/{family}.{report_type}.CH.csv"
-    target_path = f"reports/{family}.{report_type}.CH.{today}.csv"
+    symlink_path = f"reports/{family}.{report_type}.CH.{suffix}"
+    target_path = f"reports/{family}.{report_type}.CH.{today}.{suffix}"
     try:
         if os.path.islink(symlink_path) or os.path.exists(symlink_path):
             os.remove(symlink_path)
@@ -215,7 +216,7 @@ def write_report(df: pd.DataFrame, family: str, report_type: str, logger: loggin
     except Exception as e:
         logger.warning(f"Could not create symlink {symlink_path} -> {target_path}: {e}")
 
-    logger.info(f"Wrote {report_type} report to reports/{family}.{report_type}.CH.{today}.csv")
+    logger.info(f"Wrote {report_type} report to reports/{family}.{report_type}.CH.{today}.{suffix}")
 
 
 def process_sequence_variants(
@@ -705,7 +706,7 @@ def annotate_reports(
         gene_CH_status, on="Ensembl_gene_id", how="left"
     )
     sequence_variant_report = sequence_variant_report.fillna(MISSING_VALUE)
-    write_report(sequence_variant_report, family, "wgs.coding", logger)
+    write_report(sequence_variant_report, family, "wgs.coding", seq_type, logger)
 
     # Annotate panel sequence variant report
     panel_variant_report_path = glob.glob(f"{panel_variant_report_dir}/*.wgs*csv")[0]
@@ -715,7 +716,7 @@ def annotate_reports(
         gene_CH_status, on="Ensembl_gene_id", how="left"
     )
     panel_variant_report = panel_variant_report.fillna(MISSING_VALUE)
-    write_report(panel_variant_report, family, "panel", logger)
+    write_report(panel_variant_report, family, "panel", seq_type, logger)
 
     # Annotate panel-flank sequence variant report
     panel_flank_variant_report_path = glob.glob(f"{panel_flank_variant_report_dir}/*.wgs*csv")[0]
@@ -725,7 +726,7 @@ def annotate_reports(
         gene_CH_status, on="Ensembl_gene_id", how="left"
     )
     panel_flank_variant_report = panel_flank_variant_report.fillna(MISSING_VALUE)
-    write_report(panel_flank_variant_report, family, "panel-flank", logger)
+    write_report(panel_flank_variant_report, family, "panel-flank", seq_type, logger)
 
     # Annotate wgs high-impact sequence variant report
     wgs_high_impact_variant_report_path = glob.glob(f"{wgs_high_impact_variant_report_dir}/*.wgs.high.impact*csv")[0]
@@ -735,7 +736,7 @@ def annotate_reports(
         gene_CH_status, on="Ensembl_gene_id", how="left"
     )
     wgs_high_impact_variant_report = wgs_high_impact_variant_report.fillna(MISSING_VALUE)
-    write_report(wgs_high_impact_variant_report, family, "wgs.high.impact", logger)
+    write_report(wgs_high_impact_variant_report, family, "wgs.high.impact", seq_type, logger)
 
     # De novo sequence variant report (short-read pipelines only)
     if seq_type == "short" and wgs_denovo_variant_report_dir:
@@ -755,7 +756,7 @@ def annotate_reports(
             gene_CH_status, on="Ensembl_gene_id", how="left"
         )
         denovo_variant_report = denovo_variant_report.fillna(MISSING_VALUE)
-        write_report(denovo_variant_report, family, "wgs.denovo", logger)
+        write_report(denovo_variant_report, family, "wgs.denovo", seq_type, logger)
     elif seq_type == "short" and not wgs_denovo_variant_report_dir:
         logger.info(
             "Skipping de novo report CH annotation (seq_type=short but --wgs_denovo_variant_report_dir not set)"
@@ -783,7 +784,7 @@ def annotate_reports(
         for d in CH_status_series
     ]
     SV = SV.fillna(MISSING_VALUE)
-    write_report(SV, family, "sv", logger)
+    write_report(SV, family, "sv", seq_type, logger)
 
     # Annotate CNV report
     CNV = pd.read_csv(cnv_path, low_memory=False)
@@ -807,7 +808,7 @@ def annotate_reports(
         for d in CH_status_series
     ]
     CNV = CNV.fillna(MISSING_VALUE)
-    write_report(CNV, family, "cnv", logger)
+    write_report(CNV, family, "cnv", seq_type, logger)
 
 
 def main():
@@ -941,7 +942,7 @@ def main():
         }
     )
     
-    write_report(wide_variants, family, "compound.het.status", logger)
+    write_report(wide_variants, family, "compound.het.status", args.seq_type, logger)
     
     # Annotate reports
     annotate_reports(

--- a/scripts/annotate_compound_hets.py
+++ b/scripts/annotate_compound_hets.py
@@ -9,7 +9,7 @@ import pandas as pd
 import pyranges as pr
 import numpy as np
 import re
-from typing import Dict, Tuple
+from typing import Dict, Optional, Tuple
 
 from compound_hets import compound_hets
 from annotation import annotate
@@ -87,6 +87,15 @@ def parse_arguments() -> argparse.Namespace:
         type=str,
         required=True,
         help="Path to directory containing WGS high-impact variant report CSV",
+    )
+    parser.add_argument(
+        "--wgs_denovo_variant_report_dir",
+        type=str,
+        default=None,
+        help=(
+            "Directory containing WGS de novo variant report CSV "
+            "Used only when --seq_type is short (e.g. short-read pipeline); ignored for long."
+        ),
     )
     parser.add_argument("--sv", type=str, required=True, help="Path to SV report CSV")
     parser.add_argument("--cnv", type=str, required=True, help="Path to CNV report CSV")
@@ -663,6 +672,8 @@ def annotate_reports(
     panel_variant_report_dir: str,
     panel_flank_variant_report_dir: str,
     wgs_high_impact_variant_report_dir: str,
+    seq_type: str,
+    wgs_denovo_variant_report_dir: Optional[str],
     sv_path: str,
     cnv_path: str,
     family: str,
@@ -670,7 +681,11 @@ def annotate_reports(
     hpo: str,
     logger: logging.Logger,
 ) -> None:
-    """Annotate variant reports with compound het status."""
+    """Annotate variant reports with compound het status.
+
+    De novo report CH columns are written only when seq_type is "short" and
+    wgs_denovo_variant_report_dir is set.
+    """
     # Create gene-level compound het status table
     gene_CH_status = all_variants[
         ["Ensembl_gene_id", "Variant_type", "compound_het_status"]
@@ -727,6 +742,30 @@ def annotate_reports(
     )
     wgs_high_impact_variant_report = wgs_high_impact_variant_report.fillna(MISSING_VALUE)
     write_report(wgs_high_impact_variant_report, family, "wgs.high.impact", logger)
+
+    # De novo sequence variant report (short-read pipelines only)
+    if seq_type == "short" and wgs_denovo_variant_report_dir:
+        denovo_paths = glob.glob(
+            os.path.join(wgs_denovo_variant_report_dir, "*.wgs*.csv")
+        )
+        if not denovo_paths:
+            raise FileNotFoundError(
+                f"No de novo report CSV matching *.wgs.*.csv under {wgs_denovo_variant_report_dir!r}"
+            )
+        denovo_variant_report_path = denovo_paths[0]
+        denovo_variant_report = pd.read_csv(denovo_variant_report_path)
+        denovo_variant_report = compound_hets.add_hpo_terms_to_report(
+            denovo_variant_report, hpo
+        )
+        denovo_variant_report = denovo_variant_report.merge(
+            gene_CH_status, on="Ensembl_gene_id", how="left"
+        )
+        denovo_variant_report = denovo_variant_report.fillna(MISSING_VALUE)
+        write_report(denovo_variant_report, family, "wgs.denovo", logger)
+    elif seq_type == "short" and not wgs_denovo_variant_report_dir:
+        logger.info(
+            "Skipping de novo report CH annotation (seq_type=short but --wgs_denovo_variant_report_dir not set)"
+        )
 
     # Annotate SV report
     SV = pd.read_csv(sv_path, low_memory=False)
@@ -917,6 +956,8 @@ def main():
         args.panel_variant_report_dir,
         args.panel_flank_variant_report_dir,
         args.wgs_high_impact_variant_report_dir,
+        args.seq_type,
+        args.wgs_denovo_variant_report_dir,
         args.sv,
         args.cnv,
         family,

--- a/scripts/annotate_compound_hets.py
+++ b/scripts/annotate_compound_hets.py
@@ -50,6 +50,12 @@ def parse_arguments() -> argparse.Namespace:
         description="Annotate compound het status across variant types."
     )
     parser.add_argument(
+        "--seq_type",
+        type=str,
+        required=True,
+        help="Sequence type (long or short)",
+    )
+    parser.add_argument(
         "--high_med",
         type=str,
         required=True,
@@ -102,6 +108,11 @@ def parse_arguments() -> argparse.Namespace:
     parser.add_argument("--family", type=str, required=True, help="Family ID")
     return parser.parse_args()
 
+def norm_sample_id(s: str) -> str:
+  return s.replace("-", "_") # vcf2db replaces '-' with '_' in sample IDs
+
+def norm_sample_id_dict(sample_ids: list) -> Dict[str, str]:
+  return {norm_sample_id(s): s for s in sample_ids}
 
 def setup_pedigree(pedigree_path: str, family: str, logger: logging.Logger) -> Tuple[str, str, Dict[str, str]]:
     """Load pedigree and extract family information."""
@@ -206,6 +217,7 @@ def process_sequence_variants(
     ensembl: pd.DataFrame,
     ensembl_to_NCBI_df: pd.DataFrame,
     sample_order_path: str,
+    seq_type: str,
     logger: logging.Logger,
 ) -> Tuple[pd.DataFrame, pd.DataFrame]:
     """Process sequence variants and return high_impact and variant_gt_details dataframes."""
@@ -232,14 +244,22 @@ def process_sequence_variants(
     compound_hets.replace_NCBI_IDs_with_Ensembl_IDs(high_impact, ensembl, ensembl_to_NCBI_df)
 
     # Filter by TG inhouse allele count
-    high_impact["TG_LRWGS_hom"].replace(np.nan, 0, inplace=True)
-    high_impact["TG_LRWGS_hom"] = high_impact["TG_LRWGS_hom"].astype(int)
-    high_impact = high_impact[high_impact["TG_LRWGS_hom"] <= 5]
-    
+    if seq_type == "long":
+        high_impact["TG_LRWGS_hom"].replace(np.nan, 0, inplace=True)
+        high_impact["TG_LRWGS_hom"] = high_impact["TG_LRWGS_hom"].astype(int)
+        high_impact = high_impact[high_impact["TG_LRWGS_hom"] <= 5]
+
+        
     # Create variant ID
     high_impact["Variant_id"] = high_impact.apply(
         lambda x: create_variant_id(x["Chrom"], x["Pos"], x["Ref"], x["Alt"]), axis=1
     )
+
+    # Extract sample IDs
+    sample_ids = pd.read_csv(sample_order_path, header=None)[0].tolist() # comma delimited PS IDs in PS column from gemini db are in the order of the samples in the VCF
+    sample_ids_dict = norm_sample_id_dict(sample_ids) # vcf2db replaces '-' with '_' in sample IDs
+    for sample_id in sample_ids_dict.keys():
+        high_impact.columns = high_impact.columns.str.replace(sample_id, sample_ids_dict[sample_id])
 
     # Filter heterozygous variants
     high_impact = filter_heterozygous_variants(
@@ -258,23 +278,20 @@ def process_sequence_variants(
         proband_id,
     )
 
-    # Extract sample IDs
-    sample_ids = pd.read_csv(sample_order_path, header=None)[0].tolist() # comma delimited PS IDs in PS column from gemini db are in the order of the samples in the VCF
+
     # Split PS column
-    if len(sample_ids) > 1:
-        ps_split_cols = high_impact["PS"].str.split(",", expand=True)
-        for idx, sample in enumerate(sample_ids):
-            high_impact[f"PS.{sample}"] = ps_split_cols[idx]
-    else:
-        high_impact[f"PS.{sample_ids[0]}"] = high_impact["PS"]
-    high_impact.drop(columns=["PS"], inplace=True)
+    if seq_type == "long":
+        if len(sample_ids) > 1:
+            ps_split_cols = high_impact["PS"].str.split(",", expand=True)
+            for idx, sample in enumerate(sample_ids):
+                high_impact[f"PS.{sample}"] = ps_split_cols[idx]
+        else:
+            high_impact[f"PS.{sample_ids[0]}"] = high_impact["PS"]
+        high_impact.drop(columns=["PS"], inplace=True)
 
     logger.debug("Extracted %d sample IDs from sequence variant table", len(sample_ids))
 
     # Melt sample columns
-    variant_ps = compound_hets.melt_sample_columns(
-        high_impact, "Variant_id", "PS.", "PS", sample_ids
-    )
     variant_gts = compound_hets.melt_sample_columns(
         high_impact, "Variant_id", "gts.", "GT", sample_ids
     )
@@ -285,11 +302,19 @@ def process_sequence_variants(
         high_impact, "Variant_id", "gt_quals.", "GT_qual", sample_ids
     )
 
-    # Merge melted dataframes
-    dfs = [variant_ps, variant_gts, variant_gt_type, variant_qual]
+    if seq_type == "long":
+        variant_ps = compound_hets.melt_sample_columns(
+            high_impact, "Variant_id", "PS.", "PS", sample_ids
+        )
+        dfs = [variant_ps, variant_gts, variant_gt_type, variant_qual]
+    else:
+        dfs = [variant_gts, variant_gt_type, variant_qual]
+    
     sequence_variant_gt_details = merge_melted_dataframes(
         dfs, ["Variant_id", "Ref", "Alt", "Sample"]
     )
+    if seq_type == "short":
+        sequence_variant_gt_details["PS"] = MISSING_VALUE
     
     # Fix missing genotypes
     sequence_variant_gt_details.loc[
@@ -326,6 +351,7 @@ def process_structural_variants(
     proband_id: str,
     fam_dict: Dict[str, str],
     variant_type: str,
+    seq_type: str,
     logger: logging.Logger,
 ) -> pd.DataFrame:
     """Process structural variants and return variant_gt_details dataframe."""
@@ -333,9 +359,14 @@ def process_structural_variants(
     SV = pd.read_csv(sv_path, low_memory=False)
     
     # Filter rare genic variants
-    SV_rare_high_impact = SV[
-        (SV["VARIANT"] != "intergenic_region") & (SV["gnomad_maxAF"] <= 0.01) & (SV["TG_nhomalt_max"] <= 5)
-    ].copy()
+    try:
+        SV_rare_high_impact = SV[
+            (SV["VARIANT"] != "intergenic_region") & (SV["gnomad_maxAF"] <= 0.01) & (SV["TG_nhomalt_max"] <= 5)
+        ].copy()
+    except KeyError:
+        SV_rare_high_impact = SV[
+            (SV["VARIANT"] != "intergenic_region") & (SV["gnomad_maxAF"] <= 0.01)
+        ].copy()
     logger.info(
         "Identified rare genic %s variants (gnomAD AF <= 0.01)",
         variant_type,
@@ -400,7 +431,7 @@ def process_structural_variants(
     sample_ids = extract_sample_ids_from_columns(SV, "_GT")
     
     # Melt sample columns
-    if variant_type == VARIANT_TYPE_CNV:
+    if variant_type == VARIANT_TYPE_CNV or seq_type == "short":
         # CNVs don't have PS columns, create dummy dataframe with PS values as "."
         variant_ids = SV_rare_high_impact["Variant_id"].unique()
         variant_ps = pd.DataFrame({
@@ -760,17 +791,17 @@ def main():
     ensembl = pd.read_csv(args.ensembl, low_memory=False)
     ensembl_to_NCBI_df = pd.read_csv(args.ensembl_to_NCBI_df, low_memory=False)
     high_impact, sequence_variant_gt_details = process_sequence_variants(
-        args.high_med, args.low, proband_id, fam_dict, ensembl, ensembl_to_NCBI_df, args.sample_order, logger
+        args.high_med, args.low, proband_id, fam_dict, ensembl, ensembl_to_NCBI_df, args.sample_order, args.seq_type, logger
     )
     
     # Process structural variants
     SV_gt_details = process_structural_variants(
-        args.sv, proband_id, fam_dict, VARIANT_TYPE_SV, logger
+        args.sv, proband_id, fam_dict, VARIANT_TYPE_SV, args.seq_type, logger
     )
     
     # Process CNVs
     CNV_gt_details = process_structural_variants(
-        args.cnv, proband_id, fam_dict, VARIANT_TYPE_CNV, logger
+        args.cnv, proband_id, fam_dict, VARIANT_TYPE_CNV, args.seq_type, logger
     )
     
     # Combine all variant types

--- a/scripts/annotate_compound_hets.py
+++ b/scripts/annotate_compound_hets.py
@@ -289,14 +289,13 @@ def process_sequence_variants(
 
 
     # Split PS column
-    if seq_type == "long":
-        if len(sample_ids) > 1:
-            ps_split_cols = high_impact["PS"].str.split(",", expand=True)
-            for idx, sample in enumerate(sample_ids):
-                high_impact[f"PS.{sample}"] = ps_split_cols[idx]
-        else:
-            high_impact[f"PS.{sample_ids[0]}"] = high_impact["PS"]
-        high_impact.drop(columns=["PS"], inplace=True)
+    if len(sample_ids) > 1:
+        ps_split_cols = high_impact["PS"].str.split(",", expand=True)
+        for idx, sample in enumerate(sample_ids):
+            high_impact[f"PS.{sample}"] = ps_split_cols[idx]
+    else:
+        high_impact[f"PS.{sample_ids[0]}"] = high_impact["PS"]
+    high_impact.drop(columns=["PS"], inplace=True)
 
     logger.debug("Extracted %d sample IDs from sequence variant table", len(sample_ids))
 
@@ -311,19 +310,14 @@ def process_sequence_variants(
         high_impact, "Variant_id", "gt_quals.", "GT_qual", sample_ids
     )
 
-    if seq_type == "long":
-        variant_ps = compound_hets.melt_sample_columns(
-            high_impact, "Variant_id", "PS.", "PS", sample_ids
-        )
-        dfs = [variant_ps, variant_gts, variant_gt_type, variant_qual]
-    else:
-        dfs = [variant_gts, variant_gt_type, variant_qual]
+    variant_ps = compound_hets.melt_sample_columns(
+        high_impact, "Variant_id", "PS.", "PS", sample_ids
+    )
+    dfs = [variant_ps, variant_gts, variant_gt_type, variant_qual]
     
     sequence_variant_gt_details = merge_melted_dataframes(
         dfs, ["Variant_id", "Ref", "Alt", "Sample"]
     )
-    if seq_type == "short":
-        sequence_variant_gt_details["PS"] = MISSING_VALUE
     
     # Fix missing genotypes
     sequence_variant_gt_details.loc[

--- a/scripts/compound_hets/compound_hets.py
+++ b/scripts/compound_hets/compound_hets.py
@@ -84,7 +84,7 @@ def infer_pedigree_roles(pedigree: str) -> dict:
     """Map pedigree roles to individual IDs."""
     pedigree = pd.read_csv(
         pedigree,
-        sep=" ",
+        sep=None,
         header=None,
         names=[
             "family_ID",
@@ -94,6 +94,7 @@ def infer_pedigree_roles(pedigree: str) -> dict:
             "sex",
             "phenotype",
         ],
+        engine='python'
     )
     pedigree = pedigree.astype(str)
     # just take ID of first affected child if there are multiple affected children

--- a/scripts/compound_hets/compound_hets.py
+++ b/scripts/compound_hets/compound_hets.py
@@ -567,6 +567,7 @@ def add_hpo_terms_to_report(report: pd.DataFrame, hpo_terms: str) -> pd.DataFram
     # Phenotips TSV has a space in column name: " Gene symbol"
     hpo_df.columns = hpo_df.columns.str.strip()
     hpo_df = hpo_df.rename(columns={'Gene symbol': 'Gene Symbol'})
+    hpo_df = hpo_df.dropna(subset=["Gene Symbol"])
     hpo_df = hpo_df.set_index("Gene ID").drop(columns=["Gene Symbol"])
     report = report.join(hpo_df, on="Ensembl_gene_id").rename(columns={"Number of occurrences": "HPO_count", "Features": "HPO_terms"})
     

--- a/scripts/compound_hets/get_sequence_var_for_CH.sh
+++ b/scripts/compound_hets/get_sequence_var_for_CH.sh
@@ -13,9 +13,9 @@ seq_type=$3
 
 if [[ "$seq_type" == "long" ]]
 then
-    long_read_cols="PS, tg_lrwgs_ac as TG_LRWGS_ac, tg_lrwgs_hom as TG_LRWGS_hom,"
+    long_read_cols="PS as PS, tg_lrwgs_ac as TG_LRWGS_ac, tg_lrwgs_hom as TG_LRWGS_hom,"
 else
-    long_read_cols="00,"
+    long_read_cols="PS as PS,"
 fi
 
 max_af=0.01

--- a/scripts/compound_hets/get_sequence_var_for_CH.sh
+++ b/scripts/compound_hets/get_sequence_var_for_CH.sh
@@ -9,6 +9,15 @@ then
 fi
 
 severity_threshold=$2
+seq_type=$3
+
+if [[ "$seq_type" == "long" ]]
+then
+    long_read_cols="PS, tg_lrwgs_ac as TG_LRWGS_ac, tg_lrwgs_hom as TG_LRWGS_hom,"
+else
+    long_read_cols="00,"
+fi
+
 max_af=0.01
 alt_depth=3
 
@@ -28,12 +37,10 @@ sQuery="select \
         COALESCE(clinvar_pathogenic, '') || COALESCE( ';' || NULLIF(clinvar_sig,''), '') || COALESCE( ';' || NULLIF(clinvar_sig_conf,''), '') as Clinvar, \
         ensembl_gene_id as Ensembl_gene_id,\
         gnomad_af_grpmax as Gnomad_af_grpmax,\
-        tg_lrwgs_ac as TG_LRWGS_ac,\
-        tg_lrwgs_hom as TG_LRWGS_hom,\
         cadd_phred as Cadd_score,\
         COALESCE(spliceai_score, '') as SpliceAI_score,
         promoterAI as promoterAI_score,
-        PS as PS,"
+        $long_read_cols"
 
 while read sample
 do


### PR DESCRIPTION
This PR adapts the compound heterozygous module for use with DRAGEN short-read WGS (see [PR](https://github.com/ccmbioinfo/CPHI-DRAGEN-anno/pull/35)). 

Key modifications:

- `workflow/scripts/annotate_compound_hets.py` now takes an additional argument `seq_type` to denote if sequencing is short- or long-read, as well as an optional argument `wgs_denovo_variant_report_dir` to accept  a path to a de novo sequence variant report so that this report can be annotated with CH status. 
- for short-read WGS, SVs are not phased, so the phase set IDs are set to '.'.
- variants from short-read WGS are not filtered against the TG long-read in-house database

