### PR TITLE
Update slurm-submit.py

### DIFF
--- a/slurm_profile/slurm-submit.py
+++ b/slurm_profile/slurm-submit.py
@@ -24,7 +24,7 @@ RESOURCE_MAPPING = {
 jobscript = slurm_utils.parse_jobscript()
 job_properties = read_job_properties(jobscript)
 
-sbatch_options = {"tmp": "1T"}
+sbatch_options = {"constraint": "avx512"}
 cluster_config = slurm_utils.load_cluster_config(CLUSTER_CONFIG)
 
 # 1) sbatch default arguments and cluster


### PR DESCRIPTION
TRGT-denovo expects avx512 support, which some HPC nodes do not support. Add sbatch `"constraint": "avx512"` option to slurm profile to limit execution of this job to nodes that support the avx512 instruction set and avoid core dump error.