### PR TITLE
Pass reference build to peddy

### DIFF
--- a/rules/qc.smk
+++ b/rules/qc.smk
@@ -44,6 +44,7 @@ rule peddy:
         peddy \
           --prefix ./qc/peddy/{wildcards.family} \
           --plot \
+          --sites hg38 \
           {input.vcf} \
           {input.ped} \
           2>&1 | tee {log}


### PR DESCRIPTION
Peddy assumes hg37 by default. Pass hg38. 