### PR TITLE
Cleanup intermediate files

### DIFF
--- a/rules/annotation.smk
+++ b/rules/annotation.smk
@@ -15,7 +15,7 @@ rule input_prep:
     params:
         outdir= "filtered"
     output:
-        "filtered/{family}.vcf.gz"
+        temp("filtered/{family}.vcf.gz")
     wildcard_constraints:
         family = "(?!.*panel|.*coding).*"
     log:
@@ -123,7 +123,7 @@ rule vcf2db:
     input:
         "annotated/{p}/vcfanno/{family}.{p}.vep.vcfanno.vcf",
     output:
-         db="annotated/{p}/{family}-gemini.db",
+         db=temp("annotated/{p}/{family}-gemini.db"),
     log:
         "logs/vcf2db/{family}.vcf2db.{p}.log"
     threads: 1

--- a/rules/cnvreport.smk
+++ b/rules/cnvreport.smk
@@ -1,7 +1,7 @@
 rule bcftools_merge:
     input: get_cnv_dir
     output:
-        vcf = "cnv/{family}.cnv.vcf.gz"
+        vcf = temp("cnv/{family}.cnv.vcf.gz")
     log:
         "logs/cnv/{family}.cnv.bcftools.merge.log"
     conda:
@@ -23,7 +23,7 @@ rule bcftools_merge:
 rule truvari_collapse:
     input: "cnv/{family}.cnv.vcf.gz"
     output:
-        merged_variants = "cnv/{family}.cnv.truvari.merge.vcf",
+        merged_variants = temp("cnv/{family}.cnv.truvari.merge.vcf"),
         collapsed_variants = temp("cnv/{family}.cnv.truvari.collapse.vcf")
     params:
         ref = config["ref"]["genome"]
@@ -56,7 +56,7 @@ rule fix_hifi_cnv_CI:
 rule cnv_snpeff:
     input: "cnv/{family}.cnv.truvari.merge.fix.CIPOS.vcf"
     output:
-        vcf = "cnv/{family}.cnv.snpeff.vcf",
+        vcf = temp("cnv/{family}.cnv.snpeff.vcf"),
     log:
         "logs/cnv/{family}.snpeff.log"
     params:
@@ -69,7 +69,7 @@ rule cnv_snpeff:
 rule cnv_annotsv:
     input: "cnv/{family}.cnv.truvari.merge.fix.CIPOS.vcf"
     output:
-        annotsv_annotated =  "cnv/{family}.AnnotSV.tsv",
+        annotsv_annotated =  temp("cnv/{family}.AnnotSV.tsv"),
         annotsv_unannotated =  temp("cnv/{family}.AnnotSV.unannotated.tsv")
     log: "logs/cnv/{family}.annotsv.log"
     params:

--- a/rules/compound_hets.smk
+++ b/rules/compound_hets.smk
@@ -2,7 +2,7 @@ rule get_sequence_variants_for_CH:
     input:
         gemini_db="annotated/coding/{family}-gemini.db"
     output:
-        variants="small_variants/{family}.{severity}.impact.variants.tsv",
+        variants=temp("small_variants/{family}.{severity}.impact.variants.tsv"),
     params:
         severity="{severity}",
         crg2_pacbio = config["tools"]["crg2_pacbio"],
@@ -20,7 +20,7 @@ rule get_VCF_sample_order:
     input:
         vcf="annotated/coding/vcfanno/{family}.coding.vep.vcfanno.vcf.gz",
     output:
-        sample_order="small_variants/{family}.sample.order.txt",
+        sample_order=temp("small_variants/{family}.sample.order.txt"),
     log:
         "logs/compound_hets/{family}.get.VCF.sample.order.log",
     conda:

--- a/rules/outlier_expansions.smk
+++ b/rules/outlier_expansions.smk
@@ -2,7 +2,7 @@ rule genotype_adotto_loci:
     input: get_bam
     output: 
         vcf = temp("repeat_outliers/{family}_{sample}.trgt.unsorted.vcf.gz"),
-        spanning_bam = "repeat_outliers/{family}_{sample}.trgt.unsorted.spanning.bam"
+        spanning_bam = temp("repeat_outliers/{family}_{sample}.trgt.unsorted.spanning.bam")
     params: 
         trgt = config["tools"]["trgt"],
         ref = config["ref"]["genome"],
@@ -42,7 +42,7 @@ rule genotype_adotto_loci:
 
 rule sort_trgt_adotto_vcf:
     input: "repeat_outliers/{family}_{sample}.trgt.unsorted.vcf.gz"
-    output: "repeat_outliers/{family}_{sample}.trgt.sorted.vcf.gz"
+    output: temp("repeat_outliers/{family}_{sample}.trgt.sorted.vcf.gz")
     log: "logs/bcftools/{family}_{sample}.sort.trgt.log"
     conda:
         "../envs/common.yaml"

--- a/rules/pathogenic_expansion_loci.smk
+++ b/rules/pathogenic_expansion_loci.smk
@@ -2,7 +2,7 @@ rule genotype_pathogenic_loci:
     input: get_bam
     output: 
         vcf = temp("pathogenic_repeats/{family}_{sample}.trgt.unsorted.vcf.gz"),
-        spanning_bam = "pathogenic_repeats/{family}_{sample}.trgt.unsorted.spanning.bam"
+        spanning_bam = temp("pathogenic_repeats/{family}_{sample}.trgt.unsorted.spanning.bam")
     params: 
         trgt = config["tools"]["trgt"],
         ref = config["ref"]["genome"],
@@ -37,7 +37,7 @@ rule genotype_pathogenic_loci:
 
 rule sort_trgt_vcf:
     input: "pathogenic_repeats/{family}_{sample}.trgt.unsorted.vcf.gz"
-    output: "pathogenic_repeats/{family}_{sample}.trgt.vcf.gz"
+    output: temp("pathogenic_repeats/{family}_{sample}.trgt.vcf.gz")
     log: "logs/bcftools/{family}_{sample}.sort.trgt.log"
     conda:
         "../envs/common.yaml"

--- a/rules/qc.smk
+++ b/rules/qc.smk
@@ -19,7 +19,7 @@ rule peddy_unphase_vcf:
 
 rule peddy:
     input:
-        vcf="qc/peddy/{family}.unphased.vcf.gz",
+        vcf=temp("qc/peddy/{family}.unphased.vcf.gz"),
         ped=format_pedigree_qc
     output:
         pca="qc/peddy/{family}.background_pca.json",
@@ -121,7 +121,7 @@ rule add_dp_qc:
     input:
         vcf=get_smallvariants_vcf
     output:
-        "qc/bcftools/{family}.smallvariants_withdp.vcf"
+        temp("qc/bcftools/{family}.smallvariants_withdp.vcf")
     log:
         "logs/qc/bcftools/{family}.add_dp.log"
     wrapper:

--- a/rules/snvreport.smk
+++ b/rules/snvreport.smk
@@ -16,6 +16,7 @@ rule allsnvreport:
          ref=config["ref"]["genome"]
     shell:
          '''
+         set -eo pipefail
          mkdir -p {output}
          cd {output}
          ln -s ../../../{input.db} {project}-ensemble.db

--- a/rules/svreport.smk
+++ b/rules/svreport.smk
@@ -1,7 +1,7 @@
 rule snpeff:
     input: get_pbsv_vcf
     output:
-        vcf = "sv/{family}.pbsv.snpeff.vcf",
+        vcf = temp("sv/{family}.pbsv.snpeff.vcf"),
     log:
         "logs/sv/{family}.snpeff.log"
     params:
@@ -14,7 +14,7 @@ rule snpeff:
 rule annotsv:
     input: get_pbsv_vcf
     output:
-        annotsv_annotated =  "sv/{family}.AnnotSV.tsv",
+        annotsv_annotated =  temp("sv/{family}.AnnotSV.tsv"),
         annotsv_unannotated =  temp("sv/{family}.AnnotSV.unannotated.tsv")
     log: "logs/sv/{family}.annotsv.log"
     params:

--- a/scripts/annotate_SVs.py
+++ b/scripts/annotate_SVs.py
@@ -1016,7 +1016,6 @@ def main(
     print("Preparing OMIM data")
     omim_df = prepare_OMIM(f"{omim}/genemap2.txt")
 
-    df_merge.to_csv("df_merge.csv", index=False)
     df_merge["omim_phenotype"] = [
         add_omim(omim_df, gene)[0] for gene in df_merge["ENSEMBL_GENE"].values
     ]

--- a/wrappers/snpeff/wrapper.py
+++ b/wrappers/snpeff/wrapper.py
@@ -6,6 +6,7 @@ shell(
     "(snpEff {snakemake.params.java_opts} "
     "-i VCF "
     "-o VCF "
+    "-noStats "
     "-dataDir {snakemake.params.data_dir} "
     "{snakemake.params.reference} "
     "{snakemake.input} > {snakemake.output.vcf}) {log}"


### PR DESCRIPTION
Mark intermediate files as temporary so they are automatically removed by Snakemake. This will save space, and clean up the run directories.